### PR TITLE
Apply changes from latest adapter API

### DIFF
--- a/packages/adapter/build.mts
+++ b/packages/adapter/build.mts
@@ -10,7 +10,7 @@ await build({
   write: true,
   format: 'cjs',
   outdir: path.join(process.cwd(), 'dist'),
-  external: ['./node-handler'],
+  external: ['./node-handler', '@vercel/build-utils'],
 });
 
 await build({

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -24,13 +24,13 @@
     "convert-source-map": "1.8.0",
     "esbuild": "0.25.10",
     "fs-extra": "11.2.0",
-    "next": "16.0.9",
+    "next": "16.1.1-canary.18",
     "picomatch": "4.0.1",
     "source-map": "0.7.4",
     "webpack-sources": "3.2.3"
   },
   "peerDependencies": {
-    "next": "*"
+    "next": ">= 16.1.1-canary.18"
   },
   "engines": {
     "node": ">= 20.6.0"

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,12 +1,14 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
+import fs from 'node:fs/promises';
 import type { NextAdapter } from 'next';
 import type { VercelConfig } from './types';
-import { MAX_AGE_ONE_YEAR } from './constants';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
 import { escapeStringRegexp, getImagesConfig } from './utils';
 import {
   denormalizeNextDataRoutes,
+  extractHeaders,
+  extractOnMatchRoutes,
+  extractRedirects,
   modifyWithRewriteHeaders,
   normalizeNextDataRoutes,
   normalizeRewrites,
@@ -25,7 +27,7 @@ import {
 const myAdapter: NextAdapter = {
   name: 'Vercel',
   async onBuildComplete({
-    routes,
+    routing,
     config,
     buildId,
     outputs,
@@ -44,7 +46,7 @@ const myAdapter: NextAdapter = {
       outputs.appPages.length > 0 || outputs.appRoutes.length > 0;
 
     const hasPagesDir = outputs.pages.length > 0 || outputs.pagesApi.length > 0;
-    const shouldHandleMiddlewareDataResolving = hasPagesDir && hasMiddleware;
+    const shouldHandleMiddlewareDataResolving = routing.shouldNormalizeNextData;
 
     const i18nConfig = config.i18n;
     const vercelConfig: VercelConfig = {
@@ -146,7 +148,9 @@ const myAdapter: NextAdapter = {
 
         if (!parentOutput) {
           throw new Error(
-            `Invariant: missing parent output ${prerender.parentOutputId} for prerender ${JSON.stringify(prerender)}`
+            `Invariant: missing parent output ${
+              prerender.parentOutputId
+            } for prerender ${JSON.stringify(prerender)}`
           );
         }
         const parentPage = parentOutput.pathname.substring(
@@ -189,85 +193,39 @@ const myAdapter: NextAdapter = {
 
     // handle prerenders (must come after handle node outputs)
     await handlePrerenderOutputs(outputs.prerenders, {
+      config,
       vercelOutputDir,
       nodeOutputsParentMap,
     });
-
-    // TODO: should these be signaled to onBuildComplete directly
-    // somehow or should they be derived from outputs?
-    const shouldHandlePrefetchRsc = Boolean(
-      config.experimental.cacheComponents
-    );
-    const shouldHandleSegmentPrefetches = Boolean(
-      config.experimental.clientSegmentCache ||
-        config.experimental.cacheComponents
-    );
+    const shouldHandleSegmentPrefetches = outputs.appPages.length > 0;
 
     // create routes
-    const convertedRewrites = normalizeRewrites(routes.rewrites);
+    const convertedRewrites = normalizeRewrites(routing);
 
-    if (shouldHandlePrefetchRsc || shouldHandleSegmentPrefetches) {
+    if (shouldHandleSegmentPrefetches) {
       modifyWithRewriteHeaders(convertedRewrites.beforeFiles, {
-        shouldHandlePrefetchRsc,
         shouldHandleSegmentPrefetches,
       });
 
       modifyWithRewriteHeaders(convertedRewrites.afterFiles, {
         isAfterFilesRewrite: true,
-        shouldHandlePrefetchRsc,
         shouldHandleSegmentPrefetches,
       });
 
       modifyWithRewriteHeaders(convertedRewrites.fallback, {
-        shouldHandlePrefetchRsc,
         shouldHandleSegmentPrefetches,
       });
     }
 
-    const priorityRedirects: RouteWithSrc[] = [];
-    const redirects: RouteWithSrc[] = [];
-
-    for (const redirect of routes.redirects) {
-      const route: RouteWithSrc = {
-        src: redirect.sourceRegex,
-        headers: {
-          Location: redirect.destination,
-        },
-        status: redirect.statusCode,
-        has: redirect.has,
-        missing: redirect.missing,
-      };
-      if (redirect.priority) {
-        // we set continue here to prevent the redirect from
-        // moving underneath i18n routes
-        route.continue = true;
-        priorityRedirects.push(route);
-      } else {
-        redirects.push(route);
-      }
-    }
-    const headers: RouteWithSrc[] = [];
-
-    for (const route of routes.headers) {
-      headers.push({
-        src: route.sourceRegex,
-        headers: route.headers,
-        continue: true,
-        has: route.has,
-        missing: route.missing,
-
-        ...(route.priority
-          ? {
-              important: true,
-            }
-          : {}),
-      });
-    }
+    const { priority: priorityRedirects, normal: redirects } =
+      extractRedirects(routing);
+    const headers = extractHeaders(routing);
+    const onMatchRoutes = extractOnMatchRoutes(routing);
 
     const dynamicRoutes: RouteWithSrc[] = [];
     let addedNextData404Route = false;
 
-    for (const route of routes.dynamicRoutes) {
+    for (const route of routing.dynamicRoutes) {
       // add route to ensure we 404 for non-existent _next/data
       // routes before trying page dynamic routes
       if (hasPagesDir && !hasMiddleware) {
@@ -535,19 +493,77 @@ const myAdapter: NextAdapter = {
       // RSC and prefetch request handling for App Router
       ...(hasAppDir
         ? [
-            // Full RSC request rewriting
+            {
+              src: path.posix.join(
+                '/',
+                config.basePath,
+                '/(?<path>.+?)(?:/)?$'
+              ),
+              dest: path.posix.join(
+                '/',
+                config.basePath,
+                `/$path${routing.rsc.prefetchSegmentDirSuffix}/$segmentPath${routing.rsc.prefetchSegmentSuffix}`
+              ),
+              has: [
+                {
+                  type: 'header' as const,
+                  key: routing.rsc.header,
+                  value: '1',
+                },
+                {
+                  type: 'header' as const,
+                  key: routing.rsc.prefetchHeader,
+                  value: '1',
+                },
+                {
+                  type: 'header' as const,
+                  key: routing.rsc.prefetchSegmentHeader,
+                  value: '/(?<segmentPath>.+)',
+                },
+              ],
+              continue: true,
+              override: true,
+            },
+            {
+              src: path.posix.join('^/', config.basePath, '/?$'),
+              dest: path.posix.join(
+                '/',
+                config.basePath,
+                `/index${routing.rsc.prefetchSegmentDirSuffix}/$segmentPath${routing.rsc.prefetchSegmentSuffix}`
+              ),
+              has: [
+                {
+                  type: 'header' as const,
+                  key: routing.rsc.header,
+                  value: '1',
+                },
+                {
+                  type: 'header' as const,
+                  key: routing.rsc.prefetchHeader,
+                  value: '1',
+                },
+                {
+                  type: 'header' as const,
+                  key: routing.rsc.prefetchSegmentHeader,
+                  value: '/(?<segmentPath>.+)',
+                },
+              ],
+              continue: true,
+              override: true,
+            },
+
             {
               src: `^${path.posix.join('/', config.basePath, '/?')}`,
               has: [
                 {
                   type: 'header' as const,
-                  key: 'rsc',
+                  key: routing.rsc.header,
                   value: '1',
                 },
               ],
               dest: path.posix.join('/', config.basePath, '/index.rsc'),
               headers: {
-                vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+                vary: routing.rsc.varyHeader,
               },
               continue: true,
               override: true,
@@ -561,13 +577,13 @@ const myAdapter: NextAdapter = {
               has: [
                 {
                   type: 'header' as const,
-                  key: 'rsc',
+                  key: routing.rsc.header,
                   value: '1',
                 },
               ],
               dest: path.posix.join('/', config.basePath, '/$1.rsc'),
               headers: {
-                vary: 'RSC, Next-Router-State-Tree, Next-Router-Prefetch',
+                vary: routing.rsc.varyHeader,
               },
               continue: true,
               override: true,
@@ -717,7 +733,10 @@ const myAdapter: NextAdapter = {
               check: true,
             },
             {
-              src: `^${path.posix.join('/', config.basePath)}/?(?:${config.i18n.locales
+              src: `^${path.posix.join(
+                '/',
+                config.basePath
+              )}/?(?:${config.i18n.locales
                 .map((locale) => escapeStringRegexp(locale))
                 .join('|')})/(.*)`,
               dest: `${path.posix.join('/', config.basePath, '/')}$1`,
@@ -732,9 +751,7 @@ const myAdapter: NextAdapter = {
         ? [
             {
               src: '^/(?<path>.+)(?<rscSuffix>\\.segments/.+\\.segment\\.rsc)(?:/)?$',
-              dest: `/$path${
-                shouldHandlePrefetchRsc ? '.prefetch.rsc' : '.rsc'
-              }`,
+              dest: `/$path.rsc`,
               check: true,
             },
           ]
@@ -791,23 +808,9 @@ const myAdapter: NextAdapter = {
 
       { handle: 'hit' },
 
-      // Before we handle static files we need to set proper caching headers
-      {
-        // This ensures we only match known emitted-by-Next.js files and not
-        // user-emitted files which may be missing a hash in their filename.
-        src: path.posix.join(
-          '/',
-          config.basePath || '',
-          `_next/static/(?:[^/]+/pages|pages|chunks|runtime|css|image|media|${escapedBuildId})/.+`
-        ),
-        // Next.js assets contain a hash or entropy in their filenames, so they
-        // are guaranteed to be unique and cacheable indefinitely.
-        headers: {
-          'cache-control': `public,max-age=${MAX_AGE_ONE_YEAR},immutable`,
-        },
-        continue: true,
-        important: true,
-      },
+      ...onMatchRoutes,
+
+      // add internal matched path header for function bundle mapping
       {
         src:
           config.basePath && config.basePath !== '/'
@@ -823,7 +826,7 @@ const myAdapter: NextAdapter = {
         src: path.posix.join(
           '/',
           config.basePath || '',
-          `/((?!index$|_error$|500$).*?)(?:/)?$`
+          `/((?!index$).*?)(?:/)?$`
         ),
         headers: {
           'x-matched-path': '/$1',

--- a/packages/adapter/src/node-handler.ts
+++ b/packages/adapter/src/node-handler.ts
@@ -31,97 +31,6 @@ export const getHandlerSource = (ctx: {
           const relativeDistDir = process.env
             .__PRIVATE_RELATIVE_DIST_DIR as string;
 
-          interface PlainHeaders {
-            [header: string]: string | string[] | undefined;
-          }
-
-          function toPlainHeaders(headers?: Headers): PlainHeaders {
-            const result: PlainHeaders = {};
-            if (!headers) return result;
-            headers.forEach((value, key) => {
-              result[key] = value;
-              if (key.toLowerCase() === 'set-cookie') {
-                result[key] = splitCookiesString(value);
-              }
-            });
-            return result;
-          }
-
-          function splitCookiesString(cookiesString: string) {
-            const cookiesStrings: string[] = [];
-
-            let pos = 0;
-            let start: number;
-            let ch: string;
-            let lastComma: number;
-            let nextStart: number;
-            let cookiesSeparatorFound: boolean;
-
-            function skipWhitespace() {
-              while (
-                pos < cookiesString.length &&
-                /\s/.test(cookiesString.charAt(pos))
-              )
-                pos += 1;
-              return pos < cookiesString.length;
-            }
-
-            function notSpecialChar() {
-              ch = cookiesString.charAt(pos);
-              return ch !== '=' && ch !== ';' && ch !== ',';
-            }
-
-            while (pos < cookiesString.length) {
-              start = pos;
-              cookiesSeparatorFound = false;
-
-              while (skipWhitespace()) {
-                ch = cookiesString.charAt(pos);
-                if (ch === ',') {
-                  // ',' is a cookie separator if we have later first '=', not ';' or ','
-                  lastComma = pos;
-                  pos += 1;
-
-                  skipWhitespace();
-                  nextStart = pos;
-
-                  while (pos < cookiesString.length && notSpecialChar()) {
-                    pos += 1;
-                  }
-
-                  // currently special character
-                  if (
-                    pos < cookiesString.length &&
-                    cookiesString.charAt(pos) === '='
-                  ) {
-                    // we found cookies separator
-                    cookiesSeparatorFound = true;
-                    // pos is inside the next cookie, so back up and return it.
-                    pos = nextStart;
-                    cookiesStrings.push(
-                      cookiesString.substring(start, lastComma)
-                    );
-                    start = pos;
-                  } else {
-                    // in param ',' or param separator ';',
-                    // we continue from that comma
-                    pos = lastComma + 1;
-                  }
-                } else {
-                  pos += 1;
-                }
-              }
-
-              if (!cookiesSeparatorFound || pos >= cookiesString.length) {
-                cookiesStrings.push(
-                  cookiesString.substring(start, cookiesString.length)
-                );
-              }
-            }
-
-            return cookiesStrings;
-          }
-
           type Context = {
             waitUntil?: (promise: Promise<unknown>) => void;
             headers?: Record<string, string>;
@@ -139,48 +48,22 @@ export const getHandlerSource = (ctx: {
           return async function handler(request: Request): Promise<Response> {
             console.log('middleware handler', request);
 
-            function addRequestMeta(
-              req: IncomingMessage | Request,
-              key: string,
-              value: any
-            ) {
-              const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta');
-              const meta = (req as any)[NEXT_REQUEST_META] || {};
-              meta[key] = value;
-              (req as any)[NEXT_REQUEST_META] = meta;
-              return meta;
-            }
-            // we use '.' for relative project dir since we process.chdir
-            // to the same directory as the handler file so everything is
-            // relative to that/project dir
-            addRequestMeta(request, 'relativeProjectDir', '.');
-
             let middlewareHandler = await require(
               './' + path.posix.join(relativeDistDir, 'server', 'middleware.js')
             );
-            middlewareHandler = middlewareHandler.default || middlewareHandler;
+            middlewareHandler = middlewareHandler.handler || middlewareHandler;
 
             const context = getRequestContext();
-            const result = await middlewareHandler({
-              request: {
-                url: request.url,
-                method: request.method,
-                headers: toPlainHeaders(request.headers),
-                nextConfig: process.env.__PRIVATE_NEXT_CONFIG,
-                page: '/middleware',
-                body:
-                  request.method !== 'GET' && request.method !== 'HEAD'
-                    ? request.body
-                    : undefined,
-                waitUntil: context.waitUntil,
+            const response = await middlewareHandler(request, {
+              waitUntil: context.waitUntil,
+              requestMeta: {
+                // we use '.' for relative project dir since we process.chdir
+                // to the same directory as the handler file so everything is
+                // relative to that/project dir
+                relativeProjectDir: '.',
               },
             });
-
-            if (result.waitUntil && context.waitUntil) {
-              context.waitUntil(result.waitUntil);
-            }
-
-            return result.response;
+            return response;
           };
         }
       : (() => {
@@ -257,25 +140,15 @@ export const getHandlerSource = (ctx: {
             {} as Record<string, string>
           );
 
-          function addRequestMeta(
-            req: IncomingMessage,
-            key: string,
-            value: any
-          ) {
-            const NEXT_REQUEST_META = Symbol.for('NextInternalRequestMeta');
-            const meta = (req as any)[NEXT_REQUEST_META] || {};
-            meta[key] = value;
-            (req as any)[NEXT_REQUEST_META] = meta;
-            return meta;
-          }
-
           function normalizeLocalePath(
-            req: IncomingMessage,
             pathname: string,
             locales?: readonly string[]
-          ): string {
+          ): {
+            pathname: string;
+            locale?: string;
+          } {
             // If locales is undefined, return the pathname as is.
-            if (!locales) return pathname;
+            if (!locales) return { pathname };
 
             // Get the cached lowercased locales or create a new cache entry.
             const lowercasedLocales = locales.map((locale) =>
@@ -285,7 +158,7 @@ export const getHandlerSource = (ctx: {
             // The first segment will be empty, because it has a leading `/`. If
             // there is no further segment, there is no locale (or it's the default).
             const segments = pathname.split('/', 2);
-            if (!segments[1]) return pathname;
+            if (!segments[1]) return { pathname };
 
             // The second segment will contain the locale part if any.
             const segment = segments[1].toLowerCase();
@@ -293,19 +166,17 @@ export const getHandlerSource = (ctx: {
             // See if the segment matches one of the locales. If it doesn't,
             // there is no locale (or it's the default).
             const index = lowercasedLocales.indexOf(segment);
-            if (index < 0) return pathname;
+            if (index < 0) return { pathname };
 
             // Return the case-sensitive locale.
             const detectedLocale = locales[index];
             // Remove the `/${locale}` part of the pathname.
             pathname = pathname.slice(detectedLocale.length + 1) || '/';
 
-            addRequestMeta(req, 'locale', detectedLocale);
-
-            return pathname;
+            return { pathname, locale: detectedLocale };
           }
 
-          function normalizeDataPath(req: IncomingMessage, pathname: string) {
+          function normalizeDataPath(pathname: string) {
             if (!(pathname || '/').startsWith('/_next/data')) {
               return pathname;
             }
@@ -319,21 +190,30 @@ export const getHandlerSource = (ctx: {
             return pathname;
           }
 
-          function matchUrlToPage(req: IncomingMessage, urlPathname: string) {
+          function matchUrlToPage(
+            req: IncomingMessage,
+            urlPathname: string
+          ): {
+            matchedPathname: string;
+            locale?: string;
+          } {
             // normalize first
-            urlPathname = normalizeDataPath(req, urlPathname);
+            urlPathname = normalizeDataPath(urlPathname);
 
             console.log('before normalize', urlPathname);
             for (const suffixRegex of [
               /\.segments(\/.*)\.segment\.rsc$/,
-              /\.prefetch\.rsc$/,
               /\.rsc$/,
             ]) {
               urlPathname = urlPathname.replace(suffixRegex, '');
             }
             const urlPathnameWithLocale = urlPathname;
-            urlPathname = normalizeLocalePath(req, urlPathname, i18n?.locales);
-            console.log('after normalize', urlPathname);
+            const normalizeResult = normalizeLocalePath(
+              urlPathname,
+              i18n?.locales
+            );
+            urlPathname = normalizeResult.pathname;
+            console.log('after normalize', normalizeResult);
 
             urlPathname = urlPathname.replace(/\/$/, '') || '/';
 
@@ -362,12 +242,20 @@ export const getHandlerSource = (ctx: {
                 }
 
                 console.log('matched route', route, urlPathname);
-                return inversedAppRoutesManifest[route.page] || route.page;
+                return {
+                  matchedPathname:
+                    inversedAppRoutesManifest[route.page] || route.page,
+                  locale: normalizeResult.locale,
+                };
               }
             }
 
             // we should have matched above but if not return back
-            return inversedAppRoutesManifest[urlPathname] || urlPathname;
+            return {
+              matchedPathname:
+                inversedAppRoutesManifest[urlPathname] || urlPathname,
+              locale: normalizeResult.locale,
+            };
           }
 
           type Context = {
@@ -451,6 +339,14 @@ export const getHandlerSource = (ctx: {
                   waitUntil: getRequestContext().waitUntil,
                 });
               } else {
+                console.log(
+                  'failed to find 404 module',
+                  await require('fs')
+                    .promises.readdir(
+                      path.posix.join(relativeDistDir, 'server', 'pages')
+                    )
+                    .catch((err: any) => err)
+                );
                 res.end('This page could not be found');
               }
             },
@@ -461,19 +357,17 @@ export const getHandlerSource = (ctx: {
             res: import('http').ServerResponse
           ) {
             try {
-              // we use '.' for relative project dir since we process.chdir
-              // to the same directory as the handler file so everything is
-              // relative to that/project dir
-              addRequestMeta(req, 'relativeProjectDir', '.');
-
+              const parsedUrl = new URL(req.url || '/', 'http://n');
               let urlPathname = req.headers['x-matched-path'];
 
               if (typeof urlPathname !== 'string') {
                 console.log('no x-matched-path', { url: req.url });
-                const parsedUrl = new URL(req.url || '/', 'http://n');
                 urlPathname = parsedUrl.pathname || '/';
               }
-              const page = matchUrlToPage(req, urlPathname);
+              const { matchedPathname: page, locale } = matchUrlToPage(
+                req,
+                urlPathname
+              );
               const isAppDir = page.match(/\/(page|route)$/);
 
               console.log('invoking handler', {
@@ -494,6 +388,14 @@ export const getHandlerSource = (ctx: {
 
               await mod.handler(req, res, {
                 waitUntil: getRequestContext().waitUntil,
+                requestMeta: {
+                  minimalMode: true,
+                  // we use '.' for relative project dir since we process.chdir
+                  // to the same directory as the handler file so everything is
+                  // relative to that/project dir
+                  relativeProjectDir: '.',
+                  locale,
+                },
               });
             } catch (error) {
               console.error(`Failed to handle ${req.url}`, error);

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -15,6 +15,20 @@ import { AdapterOutputType } from 'next/dist/shared/lib/constants';
 import { getNextjsEdgeFunctionSource } from './get-edge-function-source';
 import { INTERNAL_PAGES } from './constants';
 
+/**
+ * Type guard to check if a prerender fallback has a filePath.
+ * The fallback can be one of two types:
+ * 1. With filePath (and optional postponedState)
+ * 2. With only postponedState (no filePath)
+ */
+function fallbackHasFilePath(
+  fallback: AdapterOutput['PRERENDER']['fallback']
+): fallback is NonNullable<AdapterOutput['PRERENDER']['fallback']> & {
+  filePath: string;
+} {
+  return fallback !== undefined && 'filePath' in fallback;
+}
+
 const copy = async (src: string, dest: string) => {
   await fse.remove(dest);
   await fse.copy(src, dest);
@@ -36,6 +50,16 @@ const writeIfNotExists = async (filePath: string, content: string) => {
   writeLock.set(filePath, writePromise);
   return writePromise;
 };
+
+function normalizeIndexPathname(pathname: string, config: NextConfig) {
+  if (pathname === config.basePath && config.basePath !== '/') {
+    return path.posix.join(config.basePath, '/index');
+  }
+  if (pathname === '/') {
+    return '/index';
+  }
+  return pathname;
+}
 
 export async function handlePublicFiles(
   publicFolder: string,
@@ -185,7 +209,7 @@ export async function handleNodeOutputs(
 
       const functionDir = path.join(
         functionsDir,
-        `${output.pathname === '/' ? '/index' : output.pathname}.func`
+        `${normalizeIndexPathname(output.pathname, config)}.func`
       );
       await fs.mkdir(functionDir, { recursive: true });
 
@@ -280,9 +304,11 @@ export async function handleNodeOutputs(
 export async function handlePrerenderOutputs(
   prerenderOutputs: Array<AdapterOutput['PRERENDER']>,
   {
+    config,
     vercelOutputDir,
     nodeOutputsParentMap,
   }: {
+    config: NextConfig;
     vercelOutputDir: string;
     nodeOutputsParentMap: Map<string, FuncOutputs[0]>;
   }
@@ -298,16 +324,18 @@ export async function handlePrerenderOutputs(
       try {
         const prerenderConfigPath = path.join(
           functionsDir,
-          `${
-            output.pathname === '/' ? '/index' : output.pathname
-          }.prerender-config.json`
+          `${normalizeIndexPathname(
+            output.pathname,
+            config
+          )}.prerender-config.json`
         );
-        const prerenderFallbackPath = output.fallback?.filePath
+        const prerenderFallbackPath = fallbackHasFilePath(output.fallback)
           ? path.join(
               functionsDir,
-              `${
-                output.pathname === '/' ? '/index' : output.pathname
-              }.prerender-fallback${path.extname(output.fallback.filePath)}`
+              `${normalizeIndexPathname(
+                output.pathname,
+                config
+              )}.prerender-fallback${path.extname(output.fallback.filePath)}`
             )
           : undefined;
 
@@ -327,15 +355,11 @@ export async function handlePrerenderOutputs(
 
         const parentFunctionDir = path.join(
           functionsDir,
-          `${
-            parentNodeOutput.pathname === '/'
-              ? '/index'
-              : parentNodeOutput.pathname
-          }.func`
+          `${normalizeIndexPathname(parentNodeOutput.pathname, config)}.func`
         );
         const prerenderFunctionDir = path.join(
           functionsDir,
-          `${output.pathname === '/' ? '/index' : output.pathname}.func`
+          `${normalizeIndexPathname(output.pathname, config)}.func`
         );
 
         if (output.pathname !== parentNodeOutput.pathname) {
@@ -365,7 +389,7 @@ export async function handlePrerenderOutputs(
 
         if (
           output.fallback?.postponedState &&
-          output.fallback.filePath &&
+          fallbackHasFilePath(output.fallback) &&
           prerenderFallbackPath
         ) {
           const fallbackHtml = await fs.readFile(
@@ -426,7 +450,7 @@ export async function handlePrerenderOutputs(
         );
 
         if (
-          output.fallback?.filePath &&
+          fallbackHasFilePath(output.fallback) &&
           prerenderFallbackPath &&
           // if postponed state is present we write the fallback file above
           !output.fallback.postponedState
@@ -484,7 +508,7 @@ export async function handleEdgeOutputs(
 
       const functionDir = path.join(
         functionsDir,
-        `${output.pathname === '/' ? 'index' : output.pathname}.func`
+        `${normalizeIndexPathname(output.pathname, config)}.func`
       );
       await fs.mkdir(functionDir, { recursive: true });
 

--- a/packages/adapter/src/routing.ts
+++ b/packages/adapter/src/routing.ts
@@ -1,19 +1,19 @@
 import type { NextAdapter, NextConfig } from 'next';
 import type { RouteWithSrc } from '@vercel/routing-utils';
 
-type AdapterRoutes = Parameters<
+type AdapterRouting = Parameters<
   NonNullable<NextAdapter['onBuildComplete']>
->[0]['routes'];
+>[0]['routing'];
+
+type AdapterRoute = AdapterRouting['beforeFiles'][0];
 
 export function modifyWithRewriteHeaders(
   rewrites: RouteWithSrc[],
   {
     isAfterFilesRewrite = false,
-    shouldHandlePrefetchRsc,
     shouldHandleSegmentPrefetches,
   }: {
     isAfterFilesRewrite?: boolean;
-    shouldHandlePrefetchRsc?: boolean;
     shouldHandleSegmentPrefetches?: boolean;
   }
 ) {
@@ -69,9 +69,6 @@ export function modifyWithRewriteHeaders(
       // PPR should match .prefetch.rsc, .rsc
       // non-PPR should match .rsc
       const parts = ['\\.rsc'];
-      if (shouldHandlePrefetchRsc) {
-        parts.push('\\.prefetch\\.rsc');
-      }
       if (shouldHandleSegmentPrefetches) {
         parts.push('\\.segments/.+\\.segment\\.rsc');
       }
@@ -116,14 +113,33 @@ export function modifyWithRewriteHeaders(
   }
 }
 
-export function normalizeRewrites(rewrites: AdapterRoutes['rewrites']): {
+/**
+ * Check if a route is a rewrite (has destination but not a redirect status)
+ */
+function isRewriteRoute(route: AdapterRoute): boolean {
+  return Boolean(route.destination) && !isRedirectStatus(route.status);
+}
+
+/**
+ * Check if a status code is a redirect status
+ */
+function isRedirectStatus(status: number | undefined): boolean {
+  return status !== undefined && [301, 302, 303, 307, 308].includes(status);
+}
+
+/**
+ * Filter and normalize rewrite routes from a routing phase
+ */
+export function normalizeRewrites(routing: {
+  beforeFiles: AdapterRoute[];
+  afterFiles: AdapterRoute[];
+  fallback: AdapterRoute[];
+}): {
   beforeFiles: RouteWithSrc[];
   afterFiles: RouteWithSrc[];
   fallback: RouteWithSrc[];
 } {
-  const normalize = (
-    item: (typeof rewrites)['beforeFiles'][0]
-  ): RouteWithSrc => ({
+  const normalize = (item: AdapterRoute): RouteWithSrc => ({
     src: item.sourceRegex,
     dest: item.destination,
     has: item.has,
@@ -132,16 +148,89 @@ export function normalizeRewrites(rewrites: AdapterRoutes['rewrites']): {
   });
 
   return {
-    beforeFiles: rewrites.beforeFiles.map((item) => {
+    beforeFiles: routing.beforeFiles.filter(isRewriteRoute).map((item) => {
       const route = normalize(item);
       delete route.check;
       route.continue = true;
       route.override = true;
       return route;
     }),
-    afterFiles: rewrites.afterFiles.map(normalize),
-    fallback: rewrites.fallback.map(normalize),
+    afterFiles: routing.afterFiles.filter(isRewriteRoute).map(normalize),
+    fallback: routing.fallback.filter(isRewriteRoute).map(normalize),
   };
+}
+
+/**
+ * Extract redirect routes from routing phases
+ */
+export function extractRedirects(routing: {
+  beforeMiddleware: AdapterRoute[];
+  beforeFiles: AdapterRoute[];
+}): {
+  priority: RouteWithSrc[];
+  normal: RouteWithSrc[];
+} {
+  const priorityRedirects: RouteWithSrc[] = [];
+  const normalRedirects: RouteWithSrc[] = [];
+
+  const processRedirects = (routes: AdapterRoute[]) => {
+    for (const route of routes) {
+      if (!isRedirectStatus(route.status)) continue;
+
+      const vercelRoute: RouteWithSrc = {
+        src: route.sourceRegex,
+        headers: route.headers,
+        status: route.status,
+        has: route.has,
+        missing: route.missing,
+      };
+
+      if (route.priority) {
+        vercelRoute.continue = true;
+        priorityRedirects.push(vercelRoute);
+      } else {
+        normalRedirects.push(vercelRoute);
+      }
+    }
+  };
+
+  processRedirects(routing.beforeMiddleware);
+  processRedirects(routing.beforeFiles);
+
+  return { priority: priorityRedirects, normal: normalRedirects };
+}
+
+/**
+ * Extract header routes from routing phases
+ */
+export function extractHeaders(routing: {
+  beforeMiddleware: AdapterRoute[];
+  beforeFiles: AdapterRoute[];
+}): RouteWithSrc[] {
+  const headers: RouteWithSrc[] = [];
+
+  const processHeaders = (routes: AdapterRoute[]) => {
+    for (const route of routes) {
+      // Headers have headers but are not redirects
+      if (!route.headers || isRedirectStatus(route.status)) continue;
+      // Skip if this is a rewrite (has destination)
+      if (route.destination) continue;
+
+      headers.push({
+        src: route.sourceRegex,
+        headers: route.headers,
+        continue: true,
+        has: route.has,
+        missing: route.missing,
+        ...(route.priority ? { important: true } : {}),
+      });
+    }
+  };
+
+  processHeaders(routing.beforeMiddleware);
+  processHeaders(routing.beforeFiles);
+
+  return headers;
 }
 
 export function normalizeNextDataRoutes(
@@ -216,6 +305,23 @@ export function normalizeNextDataRoutes(
       continue: true,
     },
   ];
+}
+
+/**
+ * Extract onMatch routes for the hit handle phase
+ */
+export function extractOnMatchRoutes(routing: {
+  onMatch: AdapterRoute[];
+}): RouteWithSrc[] {
+  return routing.onMatch.map((route) => ({
+    src: route.sourceRegex,
+    ...(route.destination ? { dest: route.destination } : {}),
+    ...(route.headers ? { headers: route.headers } : {}),
+    ...(route.has ? { has: route.has } : {}),
+    ...(route.missing ? { missing: route.missing } : {}),
+    continue: true,
+    important: true,
+  }));
 }
 
 export function denormalizeNextDataRoutes(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0
       next:
-        specifier: 16.0.9
-        version: 16.0.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: 16.1.1-canary.18
+        version: 16.1.1-canary.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       picomatch:
         specifier: 4.0.1
         version: 4.0.1
@@ -133,8 +133,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@emnapi/runtime@1.5.0':
-    resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
+  '@emnapi/runtime@1.8.1':
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
@@ -296,175 +296,186 @@ packages:
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.4':
-    resolution: {integrity: sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==}
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.4':
-    resolution: {integrity: sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.3':
-    resolution: {integrity: sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.3':
-    resolution: {integrity: sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.3':
-    resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.2.3':
-    resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.3':
-    resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.2.3':
-    resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.2.3':
-    resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
-    resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.3':
-    resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.4':
-    resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.4':
-    resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.34.4':
-    resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.4':
-    resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.4':
-    resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.4':
-    resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.4':
-    resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.4':
-    resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.4':
-    resolution: {integrity: sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.4':
-    resolution: {integrity: sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==}
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.4':
-    resolution: {integrity: sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
-  '@next/env@16.0.9':
-    resolution: {integrity: sha512-6284pl8c8n9PQidN63qjPVEu1uXXKjnmbmaLebOzIfTrSXdGiAPsIMRi4pk/+v/ezqweE1/B8bFqiAAfC6lMXg==}
+  '@next/env@16.1.1-canary.18':
+    resolution: {integrity: sha512-pAkYuydRy0Ukxr8OU9w2ZGMFfpGUi96N2LxZiC+2vVlrN2XVclGCojHx52PoiKiiGVc8SmqGQd+UckRNUrmeng==}
 
-  '@next/swc-darwin-arm64@16.0.9':
-    resolution: {integrity: sha512-j06fWg/gPqiWjK+sEpCDsh5gX+Bdy9gnPYjFqMBvBEOIcCFy1/ecF6pY6XAce7WyCJAbBPVb+6GvpmUZKNq0oQ==}
+  '@next/swc-darwin-arm64@16.1.1-canary.18':
+    resolution: {integrity: sha512-bo7+IQtqZx9TsnGp3SIP1tXldyFxp1keHfd2rct0wrXU4R/z5VlfVSJIcVqbtH/iCHhTv/U+ADAgEGZpxs+TVg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.0.9':
-    resolution: {integrity: sha512-FRYYz5GSKUkfvDSjd5hgHME2LgYjfOLBmhRVltbs3oRNQQf9n5UTQMmIu/u5vpkjJFV4L2tqo8duGqDxdQOFwg==}
+  '@next/swc-darwin-x64@16.1.1-canary.18':
+    resolution: {integrity: sha512-WQwUd14FFxamVS2Ykr/Q75CZAW3mn3wMs4QaTxp3sSBIhhez4UDuXmXcadvK6DhjTv3mfV8zw0AN/Q2E8ytp7g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.0.9':
-    resolution: {integrity: sha512-EI2klFVL8tOyEIX5J1gXXpm1YuChmDy4R+tHoNjkCHUmBJqXioYErX/O2go4pEhjxkAxHp2i8y5aJcRz2m5NqQ==}
+  '@next/swc-linux-arm64-gnu@16.1.1-canary.18':
+    resolution: {integrity: sha512-DXISOU8rhipkq2UWBy1W2Gh2c6BPzXiheC3yA3QwFNweahZ9zg72LTs0Rft7i1neAlmVa0JlitrrSv73lrCU6A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.0.9':
-    resolution: {integrity: sha512-vq/5HeGvowhDPMrpp/KP4GjPVhIXnwNeDPF5D6XK6ta96UIt+C0HwJwuHYlwmn0SWyNANqx1Mp6qSVDXwbFKsw==}
+  '@next/swc-linux-arm64-musl@16.1.1-canary.18':
+    resolution: {integrity: sha512-V/StwOwj6H4+qDweoQj4j8i/JkWSYZUn23/dn0ClnIOh7a/5WfZ0QPNZmdhTtmDpdW0VBvdI7GpR7o5g5pK+Ww==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.0.9':
-    resolution: {integrity: sha512-GlUdJwy2leA/HnyRYxJ1ZJLCJH+BxZfqV4E0iYLrJipDKxWejWpPtZUdccPmCfIEY9gNBO7bPfbG6IIgkt0qXg==}
+  '@next/swc-linux-x64-gnu@16.1.1-canary.18':
+    resolution: {integrity: sha512-9I4wGFei8SbkNVCqHkKf5YzeFz+84LF5yXuH7jZ9/z2eu54ve2IvUgPc8ny0SgUFXfo3TlpT90VDJp+Nvuitpg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.0.9':
-    resolution: {integrity: sha512-UCtOVx4N8AHF434VPwg4L0KkFLAd7pgJShzlX/hhv9+FDrT7/xCuVdlBsCXH7l9yCA/wHl3OqhMbIkgUluriWA==}
+  '@next/swc-linux-x64-musl@16.1.1-canary.18':
+    resolution: {integrity: sha512-r+EhZoqwflcT0c6NNuC9K/WpMbgfhiDiFRF8J1fv1eQhP11y+ueiVVz/M2sXsatl3Ob3HWjOfu2kHkHeq92BWQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.0.9':
-    resolution: {integrity: sha512-tQjtDGtv63mV3n/cZ4TH8BgUvKTSFlrF06yT5DyRmgQuj5WEjBUDy0W3myIW5kTRYMPrLn42H3VfCNwBH6YYiA==}
+  '@next/swc-win32-arm64-msvc@16.1.1-canary.18':
+    resolution: {integrity: sha512-bmyYmZwl4ZGu4SxSDCccxX8Pi1fxEa1939ePAW7rf1p5MnWHktXOQT2m7p13nvz8tmAT6iw3rr8ZqsNovczOWQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.0.9':
-    resolution: {integrity: sha512-y9AGACHTBwnWFLq5B5Fiv3FEbXBusdPb60pgoerB04CV/pwjY1xQNdoTNxAv7eUhU2k1CKnkN4XWVuiK07uOqA==}
+  '@next/swc-win32-x64-msvc@16.1.1-canary.18':
+    resolution: {integrity: sha512-6fbXPypxxxLan0aPZNo+XpSo0/3TM/l9T9AxFMSf3f1hwr9QKUNzTenhJyy27xYAvvDmszbgibfL5HqDVU5mFQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -517,6 +528,10 @@ packages:
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
 
+  baseline-browser-mapping@2.9.11:
+    resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
+    hasBin: true
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -562,8 +577,8 @@ packages:
       supports-color:
         optional: true
 
-  detect-libc@2.1.1:
-    resolution: {integrity: sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==}
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   emoji-regex@10.4.0:
@@ -662,8 +677,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  next@16.0.9:
-    resolution: {integrity: sha512-Xk5x/wEk6ADIAtQECLo1uyE5OagbQCiZ+gW4XEv24FjQ3O2PdSkvgsn22aaseSXC7xg84oONvQjFbSTX5YsMhQ==}
+  next@16.1.1-canary.18:
+    resolution: {integrity: sha512-HiaDfQB6T5g7BySiXhL+cQaiWifmxYKIZ0Ls55M4jZccN/qY+FcMViCeJE3P32FfKH8X80iE9eA4JnFoUQapsQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -739,13 +754,13 @@ packages:
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
 
-  sharp@0.34.4:
-    resolution: {integrity: sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==}
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   signal-exit@4.1.0:
@@ -896,7 +911,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.1.1':
     optional: true
 
-  '@emnapi/runtime@1.5.0':
+  '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -982,116 +997,124 @@ snapshots:
   '@img/colour@1.0.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.4':
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.3
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.4':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.3
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.3':
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.3':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.3':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.3':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.3':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.3':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.3':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.3':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.4':
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.3
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.34.4':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.3
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.4':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.3
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.4':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.3
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.34.4':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.3
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.4':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.3
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.4':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.3
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.34.4':
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.5.0
+      '@emnapi/runtime': 1.8.1
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.4':
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.4':
+  '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.4':
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@next/env@16.0.9': {}
+  '@next/env@16.1.1-canary.18': {}
 
-  '@next/swc-darwin-arm64@16.0.9':
+  '@next/swc-darwin-arm64@16.1.1-canary.18':
     optional: true
 
-  '@next/swc-darwin-x64@16.0.9':
+  '@next/swc-darwin-x64@16.1.1-canary.18':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.0.9':
+  '@next/swc-linux-arm64-gnu@16.1.1-canary.18':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.0.9':
+  '@next/swc-linux-arm64-musl@16.1.1-canary.18':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.0.9':
+  '@next/swc-linux-x64-gnu@16.1.1-canary.18':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.0.9':
+  '@next/swc-linux-x64-musl@16.1.1-canary.18':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.0.9':
+  '@next/swc-win32-arm64-msvc@16.1.1-canary.18':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.0.9':
+  '@next/swc-win32-x64-msvc@16.1.1-canary.18':
     optional: true
 
   '@swc/helpers@0.5.15':
@@ -1145,6 +1168,8 @@ snapshots:
 
   async-sema@3.1.1: {}
 
+  baseline-browser-mapping@2.9.11: {}
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -1178,7 +1203,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  detect-libc@2.1.1:
+  detect-libc@2.1.2:
     optional: true
 
   emoji-regex@10.4.0: {}
@@ -1302,25 +1327,26 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@16.0.9(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@16.1.1-canary.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@next/env': 16.0.9
+      '@next/env': 16.1.1-canary.18
       '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.9.11
       caniuse-lite: 1.0.30001727
       postcss: 8.4.31
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       styled-jsx: 5.1.6(react@19.1.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.0.9
-      '@next/swc-darwin-x64': 16.0.9
-      '@next/swc-linux-arm64-gnu': 16.0.9
-      '@next/swc-linux-arm64-musl': 16.0.9
-      '@next/swc-linux-x64-gnu': 16.0.9
-      '@next/swc-linux-x64-musl': 16.0.9
-      '@next/swc-win32-arm64-msvc': 16.0.9
-      '@next/swc-win32-x64-msvc': 16.0.9
-      sharp: 0.34.4
+      '@next/swc-darwin-arm64': 16.1.1-canary.18
+      '@next/swc-darwin-x64': 16.1.1-canary.18
+      '@next/swc-linux-arm64-gnu': 16.1.1-canary.18
+      '@next/swc-linux-arm64-musl': 16.1.1-canary.18
+      '@next/swc-linux-x64-gnu': 16.1.1-canary.18
+      '@next/swc-linux-x64-musl': 16.1.1-canary.18
+      '@next/swc-win32-arm64-msvc': 16.1.1-canary.18
+      '@next/swc-win32-x64-msvc': 16.1.1-canary.18
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -1368,37 +1394,39 @@ snapshots:
 
   scheduler@0.26.0: {}
 
-  semver@7.7.2:
+  semver@7.7.3:
     optional: true
 
-  sharp@0.34.4:
+  sharp@0.34.5:
     dependencies:
       '@img/colour': 1.0.0
-      detect-libc: 2.1.1
-      semver: 7.7.2
+      detect-libc: 2.1.2
+      semver: 7.7.3
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.4
-      '@img/sharp-darwin-x64': 0.34.4
-      '@img/sharp-libvips-darwin-arm64': 1.2.3
-      '@img/sharp-libvips-darwin-x64': 1.2.3
-      '@img/sharp-libvips-linux-arm': 1.2.3
-      '@img/sharp-libvips-linux-arm64': 1.2.3
-      '@img/sharp-libvips-linux-ppc64': 1.2.3
-      '@img/sharp-libvips-linux-s390x': 1.2.3
-      '@img/sharp-libvips-linux-x64': 1.2.3
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.3
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.3
-      '@img/sharp-linux-arm': 0.34.4
-      '@img/sharp-linux-arm64': 0.34.4
-      '@img/sharp-linux-ppc64': 0.34.4
-      '@img/sharp-linux-s390x': 0.34.4
-      '@img/sharp-linux-x64': 0.34.4
-      '@img/sharp-linuxmusl-arm64': 0.34.4
-      '@img/sharp-linuxmusl-x64': 0.34.4
-      '@img/sharp-wasm32': 0.34.4
-      '@img/sharp-win32-arm64': 0.34.4
-      '@img/sharp-win32-ia32': 0.34.4
-      '@img/sharp-win32-x64': 0.34.4
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   signal-exit@4.1.0: {}


### PR DESCRIPTION
This applies changes from new routing outputs in the build complete context and also cleans up the `node-handler` from the simplified handler interface removing internals usage. 