### PR TITLE
Write immutable.json for static files

### DIFF
--- a/.changeset/giant-monkeys-crash.md
+++ b/.changeset/giant-monkeys-crash.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Support immutable static files

--- a/.changeset/giant-monkeys-crash.md
+++ b/.changeset/giant-monkeys-crash.md
@@ -2,4 +2,4 @@
 "@next-community/adapter-vercel": patch
 ---
 
-Support immutable static files
+Support VERCEL_IMMUTABLE_STATIC_FILES_ENABLED and VERCEL_HASH_SALT

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -27,7 +27,7 @@
     "convert-source-map": "1.8.0",
     "esbuild": "0.25.10",
     "fs-extra": "11.2.0",
-    "next": "16.2.0-canary.79",
+    "next": "16.2.1-canary.34",
     "picomatch": "4.0.1",
     "source-map": "0.7.4",
     "webpack-sources": "3.2.3"

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -31,7 +31,6 @@ const myAdapter: NextAdapter = {
       ctx.phase === PHASE_PRODUCTION_BUILD &&
       process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID
     ) {
-      // @ts-expect-error immutable not yet published
       config.experimental.immutableAssetToken =
         process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID;
     }

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -29,10 +29,10 @@ const myAdapter: NextAdapter = {
   modifyConfig(config, ctx) {
     if (
       ctx.phase === PHASE_PRODUCTION_BUILD &&
-      process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID
+      process.env.VERCEL_IMMUTABLE_STATIC_FILES
     ) {
-      config.experimental.immutableAssetToken =
-        process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID;
+      // @ts-expect-error not merged yet
+      config.experimental.supportsImmutableAssets = true;
     }
     return config;
   },

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -29,7 +29,7 @@ const myAdapter: NextAdapter = {
   modifyConfig(config, ctx) {
     if (
       ctx.phase === PHASE_PRODUCTION_BUILD &&
-      process.env.VERCEL_IMMUTABLE_STATIC_FILES
+      process.env.VERCEL_IMMUTABLE_STATIC_FILES === '1'
     ) {
       // @ts-expect-error not merged yet
       config.experimental.supportsImmutableAssets = true;

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -31,7 +31,6 @@ const myAdapter: NextAdapter = {
       ctx.phase === PHASE_PRODUCTION_BUILD &&
       process.env.VERCEL_IMMUTABLE_STATIC_FILES === '1'
     ) {
-      // @ts-expect-error not merged yet
       config.experimental.supportsImmutableAssets = true;
     }
     return config;

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -33,6 +33,13 @@ const myAdapter: NextAdapter = {
     ) {
       config.experimental.supportsImmutableAssets = true;
     }
+
+    if (process.env.VERCEL_HASH_SALT != null) {
+      config.experimental.outputHashSalt =
+        (config.experimental.outputHashSalt ?? '') +
+        process.env.VERCEL_HASH_SALT;
+    }
+
     return config;
   },
   async onBuildComplete({

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
 import type { NextAdapter } from 'next';
-import { PHASE_PRODUCTION_BUILD } from 'next/dist/shared/lib/constants';
+import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import {
   type FuncOutputs,
   handleEdgeOutputs,

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -29,7 +29,7 @@ const myAdapter: NextAdapter = {
   modifyConfig(config, ctx) {
     if (
       ctx.phase === PHASE_PRODUCTION_BUILD &&
-      process.env.VERCEL_IMMUTABLE_STATIC_FILES === '1'
+      process.env.VERCEL_IMMUTABLE_STATIC_FILES_ENABLED === '1'
     ) {
       config.experimental.supportsImmutableAssets = true;
     }

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
 import type { NextAdapter } from 'next';
+import { PHASE_PRODUCTION_BUILD } from 'next/dist/shared/lib/constants';
 import {
   type FuncOutputs,
   handleEdgeOutputs,
@@ -25,6 +26,17 @@ import { escapeStringRegexp, getImagesConfig } from './utils';
 
 const myAdapter: NextAdapter = {
   name: 'Vercel',
+  modifyConfig(config, ctx) {
+    if (
+      ctx.phase === PHASE_PRODUCTION_BUILD &&
+      process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID
+    ) {
+      // @ts-expect-error immutable not yet published
+      config.experimental.immutableAssetToken =
+        process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID;
+    }
+    return config;
+  },
   async onBuildComplete({
     routing,
     config,

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -192,6 +192,21 @@ export async function handleStaticOutputs(
     ),
     'Not Found'
   );
+
+  const immutableFiles = outputs
+    // @ts-expect-error immutable not yet published
+    .filter((output) => output.immutable)
+    .map((output) => [
+      path.posix.join('static', output.pathname),
+      // @ts-expect-error immutable not yet published
+      output.immutable,
+    ]);
+  if (immutableFiles.length > 0) {
+    await fs.writeFile(
+      path.posix.join(vercelOutputDir, 'immutable.json'),
+      JSON.stringify(Object.fromEntries(immutableFiles))
+    );
+  }
 }
 
 const vercelConfig = JSON.parse(process.env.NEXT_ADAPTER_VERCEL_CONFIG || '{}');

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -194,11 +194,9 @@ export async function handleStaticOutputs(
   );
 
   const immutableFiles = outputs
-    // @ts-expect-error immutable not yet published
     .filter((output) => output.immutableHash)
     .map((output) => [
       path.posix.join('static', output.pathname),
-      // @ts-expect-error immutable not yet published
       output.immutableHash,
     ]);
   if (immutableFiles.length > 0) {

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -195,11 +195,11 @@ export async function handleStaticOutputs(
 
   const immutableFiles = outputs
     // @ts-expect-error immutable not yet published
-    .filter((output) => output.immutable)
+    .filter((output) => output.immutableHash)
     .map((output) => [
       path.posix.join('static', output.pathname),
       // @ts-expect-error immutable not yet published
-      output.immutable,
+      output.immutableHash,
     ]);
   if (immutableFiles.length > 0) {
     await fs.writeFile(

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -193,13 +193,18 @@ export async function handleStaticOutputs(
     'Not Found'
   );
 
-  const immutableFiles = outputs
-    .filter((output) => output.immutableHash)
-    .map((output) => [output.pathname, output.immutableHash]);
-  if (immutableFiles.length > 0) {
+  const immutableFiles: Record<string, string> = {};
+  let hasImmutableFiles = false;
+  for (const output of outputs) {
+    if (output.immutableHash) {
+      immutableFiles[output.pathname] = output.immutableHash;
+      hasImmutableFiles = true;
+    }
+  }
+  if (hasImmutableFiles) {
     await fs.writeFile(
       path.posix.join(vercelOutputDir, 'immutable.json'),
-      JSON.stringify({ version: 1, hashes: Object.fromEntries(immutableFiles) })
+      JSON.stringify({ version: 1, hashes: immutableFiles })
     );
   }
 }

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -195,10 +195,7 @@ export async function handleStaticOutputs(
 
   const immutableFiles = outputs
     .filter((output) => output.immutableHash)
-    .map((output) => [
-      path.posix.join('static', output.pathname),
-      output.immutableHash,
-    ]);
+    .map((output) => [output.pathname, output.immutableHash]);
   if (immutableFiles.length > 0) {
     await fs.writeFile(
       path.posix.join(vercelOutputDir, 'immutable.json'),

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -199,7 +199,7 @@ export async function handleStaticOutputs(
   if (immutableFiles.length > 0) {
     await fs.writeFile(
       path.posix.join(vercelOutputDir, 'immutable.json'),
-      JSON.stringify(Object.fromEntries(immutableFiles))
+      JSON.stringify({ version: 1, hashes: Object.fromEntries(immutableFiles) })
     );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0
       next:
-        specifier: 16.2.0-canary.79
-        version: 16.2.0-canary.79(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: 16.2.1-canary.34
+        version: 16.2.1-canary.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       picomatch:
         specifier: 4.0.1
         version: 4.0.1
@@ -526,53 +526,53 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@next/env@16.2.0-canary.79':
-    resolution: {integrity: sha512-PpEZ2FrI0qxLolMjOYD4umVWj1Mi7vmkUJ0BUBxO242b74+PwuogugMi+sLL1NrY6pD6INQoupg7rAdBgsYwcw==}
+  '@next/env@16.2.1-canary.34':
+    resolution: {integrity: sha512-MfLVQz6dX4wAeXhqiFHh7RTpRfAa23PnuYzYh2A/JVKQ9Ivs54Wvg3rjS99bUZmx4z2JvjQShYXA6G/YeR4L3g==}
 
-  '@next/swc-darwin-arm64@16.2.0-canary.79':
-    resolution: {integrity: sha512-UDmDEm/kYzuvUlT/BnBKMatiGHOVRghxHOSzd1f0JvgshMQisTwWV8xWX/9RzyUI/61HtqsfB40/IrQkAO4aeQ==}
+  '@next/swc-darwin-arm64@16.2.1-canary.34':
+    resolution: {integrity: sha512-pHuIDinmCt1otN5WPnEQUMQA6HFLboah5mt9aHfkHQZ96JXrs7CxpDJhSMi6bKR38JczC4WOTK6y3ljFv0p76Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.0-canary.79':
-    resolution: {integrity: sha512-AJ7TVR6JeQsMy9CNUie+2m5e1MU91WKiSKR5MwxL6pBTk3B6R/fb/Hgs5jxKaz3Jzg2EldD2iZ1lt7DwNRsl7A==}
+  '@next/swc-darwin-x64@16.2.1-canary.34':
+    resolution: {integrity: sha512-SvKsekhZ2vO8XmnGumspeF5bhwq5hIfGAsET4zYKPPpfzLKQMC9DOmov8+B1B2l1oOAkMoHaRWbT/iN97G/3KA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.0-canary.79':
-    resolution: {integrity: sha512-amxu1gLiYtWD0/SnA+tchLSqgnJ/qfnHK8z/nRRDxKF9e4My1WZ5gtbBkUlFwO7MlkG1co+SMMpFR5IEGwte6g==}
+  '@next/swc-linux-arm64-gnu@16.2.1-canary.34':
+    resolution: {integrity: sha512-oRcLVFgzVvsyRq+mDAT9bSh3e3bnnBN3tuTMx6DOJq92hdmXiQA5mpLTqW/BmGiy+c5wNpAM+Y2pxiQw2eA2vw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.0-canary.79':
-    resolution: {integrity: sha512-l5jv3HCC93iWtJBDCABg/dbNqtywVVf0qNz8n0HaJAbeKPctByAw3LYW1ih7BAFAy27J9pVjn1iXgln7UOBJ5Q==}
+  '@next/swc-linux-arm64-musl@16.2.1-canary.34':
+    resolution: {integrity: sha512-LkP1PVOyDUSXuz5n6nQ7sOxBrfvSZJVKWJefTTrY3amAMBt2VdVR33mqROKG0Ps5GveTLtuAJcCt5uvZdvZQpg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.0-canary.79':
-    resolution: {integrity: sha512-gdspoQi6s1M7Z02ZPgwH0ZWoQGMrn58+Nfv8bciW+2AmSo+0D+ogUcr7czGmQmV9AjT8BHR4GjuWcmXKI+WO7A==}
+  '@next/swc-linux-x64-gnu@16.2.1-canary.34':
+    resolution: {integrity: sha512-wziMLZzS979k4/RAqxEGkyrdRJndRUUTI5kL3KiqqZoEKP89IweNB07q9Jv4NziVqGUKfGBa8zxWsBU8vm5oiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.0-canary.79':
-    resolution: {integrity: sha512-nu3YNquYLOlcvxeH7H+S591XHlnsoYtLUdFfICageEwlnuduhofuJBuYHVsXhAZVKQJyk0RTl4DNjWN43NcpwA==}
+  '@next/swc-linux-x64-musl@16.2.1-canary.34':
+    resolution: {integrity: sha512-uhqfMkowaO3EKJmAKehiO6sIUImUCknsDwZUoo69GfuN72qVKyeG4VRrEeq5IhUmoKMtT/4ySNVeR75KjVsJUg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.0-canary.79':
-    resolution: {integrity: sha512-5PwlXNLrCdesDfl9EOeyNjcWg5wvtOFuYJq4brL0uu2uzVycbigROvPl1qZkuDPkhTakiA6yX9zP3mqRgZaqaQ==}
+  '@next/swc-win32-arm64-msvc@16.2.1-canary.34':
+    resolution: {integrity: sha512-KCTU5VV/69kHaF3vG5+yxxrJ3DCDT0SfPSBEV33Q4QvFCyj2GeKFJXs1wQm43Mjh0k5+9rfstJcn8qz3PvgrFA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.0-canary.79':
-    resolution: {integrity: sha512-klNr7RBQUFPbn1hyf0C3WXF5j+DGRChmsQkqvI/uCu5M/4yvoauYdXkkUut1tjTYMgJI+WGRQlhJBwEDwv0GLQ==}
+  '@next/swc-win32-x64-msvc@16.2.1-canary.34':
+    resolution: {integrity: sha512-9OiAdyI9DsElBqhfgGq4mbC4tdDKb3PactxfyDqmLskZ2etyb1zEXRzdMrAF9FcLRbOwsuJlOgE+iDsLk9nWgw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -948,8 +948,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  next@16.2.0-canary.79:
-    resolution: {integrity: sha512-4aXclSaLMWLz+JhugZihC1/+9jG/cfnssh7XyitOyTzfm0mmh5Kx67L9eL42yYLNxp8ZeI64t0ljNQj4wmHhow==}
+  next@16.2.1-canary.34:
+    resolution: {integrity: sha512-1frKeHysf1GVn5neMDADMWq/ITnkZzu4+4NLSqPFIyuGo44y/nCb9VncGjVdk89j7V0oJqaOL9HVl9OGNu2JDw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -1694,30 +1694,30 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@next/env@16.2.0-canary.79': {}
+  '@next/env@16.2.1-canary.34': {}
 
-  '@next/swc-darwin-arm64@16.2.0-canary.79':
+  '@next/swc-darwin-arm64@16.2.1-canary.34':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.0-canary.79':
+  '@next/swc-darwin-x64@16.2.1-canary.34':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.0-canary.79':
+  '@next/swc-linux-arm64-gnu@16.2.1-canary.34':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.0-canary.79':
+  '@next/swc-linux-arm64-musl@16.2.1-canary.34':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.0-canary.79':
+  '@next/swc-linux-x64-gnu@16.2.1-canary.34':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.0-canary.79':
+  '@next/swc-linux-x64-musl@16.2.1-canary.34':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.0-canary.79':
+  '@next/swc-win32-arm64-msvc@16.2.1-canary.34':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.0-canary.79':
+  '@next/swc-win32-x64-msvc@16.2.1-canary.34':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2101,9 +2101,9 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@16.2.0-canary.79(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@16.2.1-canary.34(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@next/env': 16.2.0-canary.79
+      '@next/env': 16.2.1-canary.34
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001727
@@ -2112,14 +2112,14 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       styled-jsx: 5.1.6(react@19.1.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.0-canary.79
-      '@next/swc-darwin-x64': 16.2.0-canary.79
-      '@next/swc-linux-arm64-gnu': 16.2.0-canary.79
-      '@next/swc-linux-arm64-musl': 16.2.0-canary.79
-      '@next/swc-linux-x64-gnu': 16.2.0-canary.79
-      '@next/swc-linux-x64-musl': 16.2.0-canary.79
-      '@next/swc-win32-arm64-msvc': 16.2.0-canary.79
-      '@next/swc-win32-x64-msvc': 16.2.0-canary.79
+      '@next/swc-darwin-arm64': 16.2.1-canary.34
+      '@next/swc-darwin-x64': 16.2.1-canary.34
+      '@next/swc-linux-arm64-gnu': 16.2.1-canary.34
+      '@next/swc-linux-arm64-musl': 16.2.1-canary.34
+      '@next/swc-linux-x64-gnu': 16.2.1-canary.34
+      '@next/swc-linux-x64-musl': 16.2.1-canary.34
+      '@next/swc-win32-arm64-msvc': 16.2.1-canary.34
+      '@next/swc-win32-x64-msvc': 16.2.1-canary.34
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
Depends on https://github.com/vercel/next.js/pull/90045

Closes PACK-6802

Generate a `.vercel/output/immutable.json` file looking like this, mapping each client-side Turbopack-emitted chunk to its full 128bit hash:
```json
{
  "version": 1,
  "hashes": {
    "_next/static/immutable/chunks/1227d17fd87ada6e.js": "1227d17fd87ada6e2e5735ab242d36e1",
    "_next/static/immutable/chunks/2e5735ab242d36e1.js": "2e5735ab242d36e1367415e237be3ade",
    "_next/static/immutable/chunks/367415e237be3ade.js": "367415e237be3adee849cb2159a24faf",
    "_next/static/immutable/chunks/turbopack-8843b62868ca6d60.js": "8843b62868ca6d60367415e237be3ade",
    "_next/static/immutable/chunks/turbopack-e849cb2159a24faf.js": "e849cb2159a24fafe849cb2159a24faf",
    "_next/static/immutable/media/vercel.c81d49bc.png": "c81d49bcb18fa799e849cb2159a24faf"
  }
}

```