### PR TITLE
Fix maxDuration precedence for node functions

### DIFF
--- a/.changeset/cold-poems-wave.md
+++ b/.changeset/cold-poems-wave.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Preserve `maxDuration` from `vercel.json` in generated node function config.

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -295,6 +295,22 @@ async function getGeneratedWorkflowLambdaOptions({
   }
 }
 
+function resolveNodeFunctionMaxDuration({
+  generatedConfigOpts,
+  outputConfigMaxDuration,
+  vercelConfigMaxDuration,
+}: {
+  generatedConfigOpts?: LambdaOptionOverrides;
+  outputConfigMaxDuration?: number;
+  vercelConfigMaxDuration?: number;
+}) {
+  return (
+    generatedConfigOpts?.maxDuration ??
+    outputConfigMaxDuration ??
+    vercelConfigMaxDuration
+  );
+}
+
 export type FuncOutputs = Array<
   | AdapterOutput['PAGES']
   | AdapterOutput['APP_PAGE']
@@ -526,8 +542,11 @@ export async function handleNodeOutputs(
       if (generatedConfigOpts) {
         Object.assign(vercelConfigOpts, generatedConfigOpts);
       }
-      const maxDuration =
-        generatedConfigOpts?.maxDuration ?? output.config.maxDuration;
+      const maxDuration = resolveNodeFunctionMaxDuration({
+        generatedConfigOpts,
+        outputConfigMaxDuration: output.config.maxDuration,
+        vercelConfigMaxDuration: vercelConfigOpts.maxDuration,
+      });
       const nodeConfig: NodeFunctionConfig = {
         ...vercelConfigOpts,
         filePathMap: files,


### PR DESCRIPTION
Fixes #51.

This restores `maxDuration` precedence for node function output generation so `vercel.json` values are preserved when there is no route export, while generated workflow config and route-level config still win when present.