### PR TITLE
Remove unused workflow tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
 
       - name: Resolve Published Adapter Version
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
These tokens aren't used as we use trusted publishing for this repo instead. 