### PR TITLE
fix: ignore example environment variables

### DIFF
--- a/.changeset/stale-maps-serve.md
+++ b/.changeset/stale-maps-serve.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Ignore example environment variables

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -346,7 +346,9 @@ async function getProjectEnvFiles(projectDir: string): Promise<string[]> {
   const projectFiles = (await fs.readdir(projectDir).catch(() => [])).sort();
 
   for (const file of projectFiles) {
-    const isEnv = file === '.env' || file.startsWith('.env.');
+    const isEnvFile = file === '.env' || file.startsWith('.env.');
+    const isIgnoredEnvFile = file === '.env.example' || file === '.env.sample';
+    const isEnv = isEnvFile && !isIgnoredEnvFile;
 
     if (!isEnv) {
       continue;

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -346,9 +346,14 @@ async function getProjectEnvFiles(projectDir: string): Promise<string[]> {
   const projectFiles = (await fs.readdir(projectDir).catch(() => [])).sort();
 
   for (const file of projectFiles) {
-    const isEnvFile = file === '.env' || file.startsWith('.env.');
-    const isIgnoredEnvFile = file === '.env.example' || file === '.env.sample';
-    const isEnv = isEnvFile && !isIgnoredEnvFile;
+    const productionEnvFiles = new Set([
+	  '.env.production.local',
+	  '.env.local',
+	  '.env.production',
+	  '.env',
+	])
+	
+	const isEnv = productionEnvFiles.has(file)
 
     if (!isEnv) {
       continue;

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -345,15 +345,15 @@ async function getProjectEnvFiles(projectDir: string): Promise<string[]> {
   const envFiles: string[] = [];
   const projectFiles = (await fs.readdir(projectDir).catch(() => [])).sort();
 
+  const productionEnvFiles = new Set([
+    '.env.production.local',
+    '.env.local',
+    '.env.production',
+    '.env',
+  ]);
+
   for (const file of projectFiles) {
-    const productionEnvFiles = new Set([
-	  '.env.production.local',
-	  '.env.local',
-	  '.env.production',
-	  '.env',
-	])
-	
-	const isEnv = productionEnvFiles.has(file)
+    const isEnv = productionEnvFiles.has(file);
 
     if (!isEnv) {
       continue;


### PR DESCRIPTION
This resubmits the commits from #55 after that PR was accidentally closed when its fork branch was reset to `main` during signature cleanup.

The commit series is unchanged in content and has been replayed so every commit has a valid signature.

Original PR: #55

We're getting warnings for `.env.example` environment variables for nextjs builds on vercel. I think those should be ignored.

I just ignored `.env.example` and `.env.sample` for simplicity. Alternatively, we could use only environment variables used by `@next/env` but I felt like that was a bit of overengineering for this