### PR TITLE
Use GitHub API commit mode for changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           publish: pnpm changeset publish
           title: "chore: version packages"
           commit: "chore: version packages"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- configure changesets/action release workflow to use commitMode: github-api

## Testing
- not run; workflow-only change