### PR TITLE
ctx.projectDir might be undefined on older versions

### DIFF
--- a/.changeset/giant-dodos-pump.md
+++ b/.changeset/giant-dodos-pump.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+ctx.projectDir might be undefined on older versions

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -43,7 +43,9 @@ const myAdapter: NextAdapter = {
 
     if (
       ctx.phase === PHASE_PRODUCTION_BUILD &&
-      process.env.VERCEL_PREVIEW_COMMENTS_ENABLED === '1'
+      process.env.VERCEL_PREVIEW_COMMENTS_ENABLED === '1' &&
+      // Only available in newer Next.js versions
+      typeof ctx.projectDir !== 'undefined'
     ) {
       // This script has to live inside of the project directory since Turbopack can't read file
       // files outside of the project directory.


### PR DESCRIPTION
Gracefully fall back if projectDir isn't passed yet by Next.js

Otherwise you'd see
```
TypeError: The "path" argument must be of type string. Received undefined
  at ignore-listed frames {
code: 'ERR_INVALID_ARG_TYPE'
}
```