### PR TITLE
Fix output type tracking for API routes

### DIFF
--- a/.changeset/gold-stamps-run.md
+++ b/.changeset/gold-stamps-run.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Fix output type tracking for API routes

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -551,7 +551,8 @@ export async function handleNodeOutputs(
       }
 
       const operationType =
-        output.type === AdapterOutputType.APP_PAGE || AdapterOutputType.PAGES
+        output.type === AdapterOutputType.APP_PAGE ||
+        output.type === AdapterOutputType.PAGES
           ? 'PAGE'
           : 'API';
 


### PR DESCRIPTION
The code as written would always be truthy, since `AdapterOutputType.PAGES` is a non-empty string. This means every single `operationType` is set as `PAGE`, even for route handlers and middleware.