### PR TITLE
Fix usesSrcDirectory caching

### DIFF
--- a/.changeset/fiery-candies-bet.md
+++ b/.changeset/fiery-candies-bet.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Fix usesSrcDirectory caching

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -1007,13 +1007,12 @@ export async function handleMiddleware(
   return routes;
 }
 
-// We only need this once per build
+// We only need to compute this once per build
 let _usesSrcCache: boolean | undefined;
 
 async function usesSrcDirectory(workPath: string): Promise<boolean> {
-  if (!_usesSrcCache) {
+  if (_usesSrcCache === undefined) {
     const sourcePages = path.join(workPath, 'src', 'pages');
-
     try {
       if ((await fs.stat(sourcePages)).isDirectory()) {
         _usesSrcCache = true;
@@ -1023,9 +1022,8 @@ async function usesSrcDirectory(workPath: string): Promise<boolean> {
     }
   }
 
-  if (!_usesSrcCache) {
+  if (_usesSrcCache === undefined) {
     const sourceAppdir = path.join(workPath, 'src', 'app');
-
     try {
       if ((await fs.stat(sourceAppdir)).isDirectory()) {
         _usesSrcCache = true;
@@ -1035,7 +1033,10 @@ async function usesSrcDirectory(workPath: string): Promise<boolean> {
     }
   }
 
-  return Boolean(_usesSrcCache);
+  if (_usesSrcCache === undefined) {
+    _usesSrcCache = false;
+  }
+  return _usesSrcCache;
 }
 
 function isDirectory(path: string) {


### PR DESCRIPTION
`if (!_usesSrcCache)` on `_usesSrcCache: boolean | undefined` would still keep rerunning the detection on `false`