### PR TITLE
Remove peerDependency on next

### DIFF
--- a/.changeset/pink-chefs-train.md
+++ b/.changeset/pink-chefs-train.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Remove peerDependency on next

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -32,9 +32,6 @@
     "source-map": "0.7.4",
     "webpack-sources": "3.2.3"
   },
-  "peerDependencies": {
-    "next": ">= 16.1.1-canary.18"
-  },
   "engines": {
     "node": ">= 20.6.0"
   }


### PR DESCRIPTION
The build step bundles this in to the adapter anyway. It's enough if it's a dev dependency