### PR TITLE
Fix usesSrcDirectory regression

### DIFF
--- a/.changeset/fiery-candies-bet.md
+++ b/.changeset/fiery-candies-bet.md
@@ -1,5 +1,0 @@
----
-"@next-community/adapter-vercel": patch
----
-
-Fix usesSrcDirectory caching

--- a/.changeset/fiery-candies-bet.md
+++ b/.changeset/fiery-candies-bet.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Fix usesSrcDirectory caching

--- a/.changeset/thin-readers-train.md
+++ b/.changeset/thin-readers-train.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Fix usesSrcDirectory regression

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -478,6 +478,8 @@ export async function handleNodeOutputs(
     );
   }
 
+  const usesSrcDir = await usesSrcDirectory(projectDir);
+
   await Promise.all(
     nodeOutputs.map(async (output) => {
       await fsSema.acquire();
@@ -560,6 +562,7 @@ export async function handleNodeOutputs(
         workPath: projectDir,
         page: output.sourcePage,
         pageExtensions: config.pageExtensions || [],
+        usesSrcDir,
       });
       const vercelConfigOpts = await getLambdaOptionsFromFunction({
         sourceFile,
@@ -1008,35 +1011,19 @@ export async function handleMiddleware(
   return routes;
 }
 
-// We only need this once per build
-let _usesSrcCache: boolean | undefined;
-
 async function usesSrcDirectory(workPath: string): Promise<boolean> {
-  if (!_usesSrcCache) {
-    const sourcePages = path.join(workPath, 'src', 'pages');
-
+  for (const dir of [
+    path.join(workPath, 'src', 'pages'),
+    path.join(workPath, 'src', 'app'),
+  ]) {
     try {
-      if ((await fs.stat(sourcePages)).isDirectory()) {
-        _usesSrcCache = true;
+      if ((await fs.stat(dir)).isDirectory()) {
+        return true;
       }
-    } catch (_err) {
-      _usesSrcCache = false;
-    }
+    } catch (_err) {}
   }
 
-  if (!_usesSrcCache) {
-    const sourceAppdir = path.join(workPath, 'src', 'app');
-
-    try {
-      if ((await fs.stat(sourceAppdir)).isDirectory()) {
-        _usesSrcCache = true;
-      }
-    } catch (_err) {
-      _usesSrcCache = false;
-    }
-  }
-
-  return Boolean(_usesSrcCache);
+  return false;
 }
 
 function isDirectory(path: string) {
@@ -1047,12 +1034,13 @@ async function getSourceFilePathFromPage({
   workPath,
   page,
   pageExtensions,
+  usesSrcDir,
 }: {
   workPath: string;
   page: string;
   pageExtensions?: ReadonlyArray<string>;
+  usesSrcDir: boolean;
 }) {
-  const usesSrcDir = await usesSrcDirectory(workPath);
   const extensionsToTry = pageExtensions || ['js', 'jsx', 'ts', 'tsx'];
 
   for (const pageType of [

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -1008,12 +1008,13 @@ export async function handleMiddleware(
   return routes;
 }
 
-// We only need to compute this once per build
+// We only need this once per build
 let _usesSrcCache: boolean | undefined;
 
 async function usesSrcDirectory(workPath: string): Promise<boolean> {
-  if (_usesSrcCache === undefined) {
+  if (!_usesSrcCache) {
     const sourcePages = path.join(workPath, 'src', 'pages');
+
     try {
       if ((await fs.stat(sourcePages)).isDirectory()) {
         _usesSrcCache = true;
@@ -1023,8 +1024,9 @@ async function usesSrcDirectory(workPath: string): Promise<boolean> {
     }
   }
 
-  if (_usesSrcCache === undefined) {
+  if (!_usesSrcCache) {
     const sourceAppdir = path.join(workPath, 'src', 'app');
+
     try {
       if ((await fs.stat(sourceAppdir)).isDirectory()) {
         _usesSrcCache = true;
@@ -1034,10 +1036,7 @@ async function usesSrcDirectory(workPath: string): Promise<boolean> {
     }
   }
 
-  if (_usesSrcCache === undefined) {
-    _usesSrcCache = false;
-  }
-  return _usesSrcCache;
+  return Boolean(_usesSrcCache);
 }
 
 function isDirectory(path: string) {

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -1040,7 +1040,7 @@ async function usesSrcDirectory(workPath: string): Promise<boolean> {
 }
 
 function isDirectory(path: string) {
-  return fse.existsSync(path) && fse.lstatSync(path).isDirectory();
+  return fse.lstatSync(path, { throwIfNoEntry: false })?.isDirectory() ?? false;
 }
 
 async function getSourceFilePathFromPage({


### PR DESCRIPTION
Fixes a regression from #72

The intended behavior was:
```
if(notCached) checkSrcAppDir()
if(notCached) checkSrcPagesDir()
return false
```
The actual behavior was
```
if(cachedValue == undefined) { cachedValue = doesSrcPagesDirExist(); }
if(cachedValue == undefined) { cachedValue = doesSrcAppDirExist(); }
if(cachedValue == undefined) { cachedValue = false; }
return cachedValue
```

which, when we remove the try-catch wrappers that obscure the assignment, is plain wrong.

Remove the cache by just hoisting the call and passing the boolean into the loop.