### PR TITLE
Fix i18n routing for API paths

### DIFF
--- a/.changeset/fix-i18n-api-routes.md
+++ b/.changeset/fix-i18n-api-routes.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Prevent i18n routing from adding or removing locale prefixes for API routes.

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -13,10 +13,12 @@ import {
   handleStaticOutputs,
 } from './outputs';
 import {
+  API_PATH_PREFIX_PATTERN,
   denormalizeNextDataRoutes,
   extractHeaders,
   extractOnMatchRoutes,
   extractRedirects,
+  getI18nPathPrefixExclusion,
   modifyWithRewriteHeaders,
   normalizeNextDataRoutes,
   normalizeRewrites,
@@ -95,6 +97,9 @@ const myAdapter: NextAdapter = {
     const shouldHandleMiddlewareDataResolving = routing.shouldNormalizeNextData;
 
     const i18nConfig = config.i18n;
+    const i18nPathPrefixExclusion = i18nConfig
+      ? getI18nPathPrefixExclusion(i18nConfig.locales)
+      : '';
     const vercelConfig: VercelConfig = {
       version: 3,
       overrides: {},
@@ -352,9 +357,7 @@ const myAdapter: NextAdapter = {
                 '/',
                 config.basePath,
                 '/'
-              )}(?!(?:_next/.*|${config.i18n.locales
-                .map((locale) => escapeStringRegexp(locale))
-                .join('|')})(?:/.*|$))(.*)$`,
+              )}${i18nPathPrefixExclusion}(.*)$`,
               // we aren't able to ensure trailing slash mode here
               // so ensure this comes after the trailing slash redirect
               dest: `${
@@ -452,9 +455,7 @@ const myAdapter: NextAdapter = {
                 '/',
                 config.basePath,
                 '/'
-              )}(?!(?:_next/.*|${config.i18n.locales
-                .map((locale) => escapeStringRegexp(locale))
-                .join('|')})(?:/.*|$))(.*)$`,
+              )}${i18nPathPrefixExclusion}(.*)$`,
               dest: `${path.posix.join(
                 '/',
                 config.basePath,
@@ -763,9 +764,7 @@ const myAdapter: NextAdapter = {
                       '/',
                       config.basePath,
                       '/'
-                    )}(?!(?:_next/.*|${config.i18n.locales
-                      .map((locale) => escapeStringRegexp(locale))
-                      .join('|')})(?:/.*|$))(.*)$`,
+                    )}${i18nPathPrefixExclusion}(.*)$`,
                     dest: `${path.posix.join(
                       '/',
                       config.basePath,
@@ -790,7 +789,7 @@ const myAdapter: NextAdapter = {
                 config.basePath
               )}/?(?:${config.i18n.locales
                 .map((locale) => escapeStringRegexp(locale))
-                .join('|')})/(.*)`,
+                .join('|')})/(?!${API_PATH_PREFIX_PATTERN})(.*)`,
               dest: `${path.posix.join('/', config.basePath, '/')}$1`,
               check: true,
             },

--- a/packages/adapter/src/routing.ts
+++ b/packages/adapter/src/routing.ts
@@ -1,11 +1,24 @@
 import type { RouteWithSrc } from '@vercel/routing-utils';
 import type { NextAdapter, NextConfig } from 'next';
+import { escapeStringRegexp } from './utils';
 
 type AdapterRouting = Parameters<
   NonNullable<NextAdapter['onBuildComplete']>
 >[0]['routing'];
 
 type AdapterRoute = AdapterRouting['beforeFiles'][0];
+
+export const API_PATH_PREFIX_PATTERN = 'api(?:/.*|$)';
+
+/**
+ * Prevent Vercel's internal i18n routing from adding a locale prefix to
+ * framework-internal assets, Pages API routes, and already-localized paths.
+ */
+export function getI18nPathPrefixExclusion(locales: readonly string[]): string {
+  return `(?!(?:_next/.*|api|${locales
+    .map((locale) => escapeStringRegexp(locale))
+    .join('|')})(?:/.*|$))`;
+}
 
 export function modifyWithRewriteHeaders(
   rewrites: RouteWithSrc[],


### PR DESCRIPTION
## Summary

[vercel/next.js#94905](https://github.com/vercel/next.js/pull/94905) made Adapter API matchers for Pages API routes use the canonical `/api` namespace. The adapter-generated i18n routes could rewrite `/api/*` to `/{locale}/api/*` before those matchers ran, causing the API function to be missed and the request to fall through to another rewrite.

- Exclude `/api` and `/api/*` from locale-prefixing routes, including wildcard-domain and locale-detection fallbacks.
- Prevent locale-removal routes from exposing API functions at `/{locale}/api/*`.
- Share the escaped i18n path exclusion across generated routes.

## Verification

- `biome check packages/adapter/src/index.ts packages/adapter/src/routing.ts .changeset/fix-i18n-api-routes.md`
- Manually validated matcher behavior for `/api`, `/api/blog/first`, `/blog`, `/apiary`, `/en/api/hello`, and `/en/blog`.
- Not run: `pnpm --filter @next-community/adapter-vercel build` (the installed dependencies belong to the older beta.20 checkout and do not contain current `main` Adapter API fields).

<!-- NEXT_JS_LLM_PR -->

e2e test run: https://github.com/vercel/next.js/actions/runs/29091374760