### PR TITLE
pages404Output might be a static file

### DIFF
--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
-import type { AdapterOutput, NextAdapter } from 'next';
+import type { NextAdapter } from 'next';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import {
   type FuncOutputs,
@@ -22,7 +22,7 @@ import {
   normalizeRewrites,
 } from './routing';
 import { generateToolbarScript } from './toolbar';
-import type { VercelConfig } from './types';
+import type { OutputPageOrStaticPrerender, VercelConfig } from './types';
 import { escapeStringRegexp, getImagesConfig } from './utils';
 
 const myAdapter: NextAdapter = {
@@ -143,32 +143,6 @@ const myAdapter: NextAdapter = {
     const nodeOutputsParentMap = new Map<string, FuncOutputs[0]>();
     const edgeOutputs: FuncOutputs = [];
     const nodeOutputs: FuncOutputs = [];
-
-    let outputNotFound:
-      | AdapterOutput['PAGES']
-      | AdapterOutput['STATIC_FILE']
-      | undefined;
-    let output404:
-      | AdapterOutput['PAGES']
-      | AdapterOutput['STATIC_FILE']
-      | undefined;
-    let output500:
-      | AdapterOutput['PAGES']
-      | AdapterOutput['STATIC_FILE']
-      | undefined;
-
-    for (const output of [...outputs.pages, ...outputs.staticFiles]) {
-      if (output.pathname.endsWith('/_not-found')) {
-        outputNotFound = output;
-      }
-      if (output.pathname.endsWith('/404')) {
-        output404 = output;
-      }
-      if (output.pathname.endsWith('/500')) {
-        output500 = output;
-      }
-    }
-
     for (const output of [
       ...outputs.appPages,
       ...outputs.appRoutes,
@@ -185,25 +159,45 @@ const myAdapter: NextAdapter = {
       }
     }
 
-    // TODO why do we need this?
-    if (output404) {
-      outputNotFound = undefined;
-    }
+    let pagesNotFoundOutput: OutputPageOrStaticPrerender | undefined;
+    let pages404Output: OutputPageOrStaticPrerender | undefined;
+    let output500: OutputPageOrStaticPrerender | undefined;
 
-    for (const output of outputs.staticFiles) {
+    for (const output of [
+      ...outputs.pages,
+      // TODO can /500 actually occur in app pages?
+      ...outputs.appPages,
+      ...outputs.staticFiles,
+    ]) {
+      // TODO all of these should really be checking `path.posix.join('/', config.basePath || '', '/404')`
       if (output.pathname.endsWith('/_not-found')) {
-        outputNotFound = output;
+        pagesNotFoundOutput = output;
       }
       if (output.pathname.endsWith('/404')) {
-        output404 = output;
+        pages404Output = output;
       }
       if (output.pathname.endsWith('/500')) {
         output500 = output;
       }
     }
-    const notFoundPath = outputNotFound
+    // TODO why do we need this?
+    if (pages404Output) {
+      pagesNotFoundOutput = undefined;
+    }
+    for (const output of outputs.staticFiles) {
+      if (output.pathname.endsWith('/_not-found')) {
+        pagesNotFoundOutput = output;
+      }
+      if (output.pathname.endsWith('/404')) {
+        pages404Output = output;
+      }
+      if (output.pathname.endsWith('/500')) {
+        output500 = output;
+      }
+    }
+    const notFoundPath = pagesNotFoundOutput
       ? '/_not-found'
-      : output404
+      : pages404Output
         ? '/404'
         : '/_error';
 
@@ -269,6 +263,7 @@ const myAdapter: NextAdapter = {
       nextVersion,
       vercelOutputDir,
       prerenderFallbackFalseMap,
+      pages404Output: pages404Output,
     });
 
     // handle prerenders (must come after handle node outputs)

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
-import type { NextAdapter } from 'next';
+import type { AdapterOutput, NextAdapter } from 'next';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
 import {
   type FuncOutputs,
@@ -82,6 +82,23 @@ const myAdapter: NextAdapter = {
     projectDir,
     nextVersion,
   }) {
+    await fs.writeFile(
+      'build-complete.json',
+      JSON.stringify(
+        {
+          routing,
+          config,
+          buildId,
+          outputs,
+          distDir,
+          repoRoot,
+          projectDir,
+          nextVersion,
+        },
+        null,
+        2
+      )
+    );
     const vercelOutputDir = path.join(distDir, 'output');
     await fs.mkdir(vercelOutputDir, { recursive: true });
 
@@ -127,28 +144,37 @@ const myAdapter: NextAdapter = {
     const edgeOutputs: FuncOutputs = [];
     const nodeOutputs: FuncOutputs = [];
 
-    let hasNotFoundOutput = false;
-    let has404Output = false;
-    let has500Output = false;
+    let outputNotFound:
+      | AdapterOutput['PAGES']
+      | AdapterOutput['STATIC_FILE']
+      | undefined;
+    let output404:
+      | AdapterOutput['PAGES']
+      | AdapterOutput['STATIC_FILE']
+      | undefined;
+    let output500:
+      | AdapterOutput['PAGES']
+      | AdapterOutput['STATIC_FILE']
+      | undefined;
+
+    for (const output of [...outputs.pages, ...outputs.staticFiles]) {
+      if (output.pathname.endsWith('/_not-found')) {
+        outputNotFound = output;
+      }
+      if (output.pathname.endsWith('/404')) {
+        output404 = output;
+      }
+      if (output.pathname.endsWith('/500')) {
+        output500 = output;
+      }
+    }
 
     for (const output of [
       ...outputs.appPages,
       ...outputs.appRoutes,
       ...outputs.pages,
       ...outputs.pagesApi,
-      ...outputs.staticFiles,
     ]) {
-      if (output.pathname.endsWith('/404')) {
-        hasNotFoundOutput = false;
-        has404Output = true;
-      }
-      if (!has404Output && output.pathname.endsWith('/_not-found')) {
-        hasNotFoundOutput = true;
-      }
-      if (output.pathname.endsWith('/500')) {
-        has500Output = true;
-      }
-
       if ('runtime' in output) {
         if (output.runtime === 'nodejs') {
           nodeOutputsParentMap.set(output.id, output);
@@ -159,20 +185,25 @@ const myAdapter: NextAdapter = {
       }
     }
 
+    // TODO why do we need this?
+    if (output404) {
+      outputNotFound = undefined;
+    }
+
     for (const output of outputs.staticFiles) {
       if (output.pathname.endsWith('/_not-found')) {
-        hasNotFoundOutput = true;
+        outputNotFound = output;
       }
       if (output.pathname.endsWith('/404')) {
-        has404Output = true;
+        output404 = output;
       }
       if (output.pathname.endsWith('/500')) {
-        has500Output = true;
+        output500 = output;
       }
     }
-    const notFoundPath = hasNotFoundOutput
+    const notFoundPath = outputNotFound
       ? '/_not-found'
-      : has404Output
+      : output404
         ? '/404'
         : '/_error';
 
@@ -937,7 +968,7 @@ const myAdapter: NextAdapter = {
           ]),
 
       // custom 500 page if present
-      ...(config.i18n && has500Output
+      ...(config.i18n && output500
         ? [
             {
               src: `${path.posix.join(
@@ -974,7 +1005,7 @@ const myAdapter: NextAdapter = {
               dest: path.posix.join(
                 '/',
                 config.basePath,
-                has500Output ? '/500' : '/_error'
+                output500 ? '/500' : '/_error'
               ),
               status: 500,
             },

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -14,7 +14,7 @@ import { AdapterOutputType } from 'next/dist/shared/lib/constants';
 import type { NextjsParams } from './get-edge-function-source';
 import { getNextjsEdgeFunctionSource } from './get-edge-function-source';
 import { getHandlerSource } from './node-handler';
-import type { VercelConfig } from './types';
+import type { OutputPageOrStaticPrerender, VercelConfig } from './types';
 import { sha256 } from './utils';
 
 /**
@@ -396,6 +396,7 @@ export async function handleNodeOutputs(
     isMiddleware,
     prerenderFallbackFalseMap,
     vercelOutputDir,
+    pages404Output,
   }: {
     config: NextConfig;
     distDir: string;
@@ -405,6 +406,7 @@ export async function handleNodeOutputs(
     isMiddleware?: boolean;
     prerenderFallbackFalseMap: Record<string, string[]>;
     vercelOutputDir: string;
+    pages404Output: OutputPageOrStaticPrerender | undefined;
   }
 ) {
   const nodeVersion = await getNodeVersion(
@@ -418,20 +420,13 @@ export async function handleNodeOutputs(
   const functionsDir = path.join(vercelOutputDir, 'functions');
   const handlerRelativeDir = path.posix.relative(repoRoot, projectDir);
 
-  let pages404Output: undefined | FuncOutputs[0];
   let pagesErrorOutput: undefined | FuncOutputs[0];
 
   for (const item of nodeOutputs) {
-    if (item.pathname === path.posix.join('/', config.basePath || '', '/404')) {
-      pages404Output = item;
-    }
     if (
       item.pathname === path.posix.join('/', config.basePath || '', '/_error')
     ) {
       pagesErrorOutput = item;
-    }
-
-    if (pages404Output && pagesErrorOutput) {
       break;
     }
   }
@@ -512,12 +507,14 @@ export async function handleNodeOutputs(
         const notFoundOutput = pages404Output || pagesErrorOutput;
 
         if (notFoundOutput) {
-          for (const [relPath, fsPath] of Object.entries(
-            notFoundOutput.assets
-          )) {
-            files[relPath] = path.posix.relative(repoRoot, fsPath);
-            if (filesHashes) {
-              filesHashes[relPath] = notFoundOutput.assetsHashes?.[relPath];
+          if (notFoundOutput.type !== AdapterOutputType.STATIC_FILE) {
+            for (const [relPath, fsPath] of Object.entries(
+              notFoundOutput.assets
+            )) {
+              files[relPath] = path.posix.relative(repoRoot, fsPath);
+              if (filesHashes) {
+                filesHashes[relPath] = notFoundOutput.assetsHashes?.[relPath];
+              }
             }
           }
           files[path.posix.relative(repoRoot, notFoundOutput.filePath)] =
@@ -984,6 +981,7 @@ export async function handleMiddleware(
     await handleNodeOutputs([output], {
       ...ctx,
       isMiddleware: true,
+      pages404Output: undefined,
     });
   } else if (output.runtime === 'edge') {
     await handleEdgeOutputs([output], ctx);

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -1,4 +1,5 @@
 import type { Route } from '@vercel/routing-utils';
+import type { AdapterOutput } from 'next';
 
 type ImageFormat = 'image/avif' | 'image/webp';
 
@@ -48,3 +49,8 @@ export type VercelConfig = {
   overrides: OverridesConfig;
   cache?: string[];
 };
+
+export type OutputPageOrStaticPrerender =
+  | AdapterOutput['PAGES']
+  | AdapterOutput['APP_PAGE']
+  | AdapterOutput['STATIC_FILE'];


### PR DESCRIPTION
pages404Output might be a static file, so the `const item of nodeOutputs` loop in `outputs.ts` woudln't find it in there.

Instead, pass it down.

I plan on making it use the 404.js file instead to not include the prerender in the serverless function. But that is just an optimization. This PR fixes the behavioral bug