### PR TITLE
Add missing assetHash for Pages 404

### DIFF
--- a/.changeset/salty-doodles-worry.md
+++ b/.changeset/salty-doodles-worry.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Add missing assetHash for Pages 404

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -520,8 +520,14 @@ export async function handleNodeOutputs(
               filesHashes[relPath] = notFoundOutput.assetsHashes?.[relPath];
             }
           }
-          files[path.posix.relative(repoRoot, notFoundOutput.filePath)] =
-            path.posix.relative(repoRoot, notFoundOutput.filePath);
+          const relPath = path.posix.relative(
+            repoRoot,
+            notFoundOutput.filePath
+          );
+          files[relPath] = relPath;
+          if (filesHashes) {
+            filesHashes[relPath] = notFoundOutput.assetsHashes?.[relPath];
+          }
         }
       }
 


### PR DESCRIPTION
When adding the 404 Pages handler output to another Pages route, I forgot to copy over the assetHash for the entry file (it was only being copied for the subassets)