### PR TITLE
Fix assetHash key of the launcher

### DIFF
--- a/.changeset/frank-camels-marry.md
+++ b/.changeset/frank-camels-marry.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Fix assetHash key of the launcher

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -416,7 +416,6 @@ export async function handleNodeOutputs(
 
   const fsSema = new Sema(16, { capacity: nodeOutputs.length });
   const functionsDir = path.join(vercelOutputDir, 'functions');
-  const handlerRelativeDir = path.posix.relative(repoRoot, projectDir);
 
   let pages404Output: undefined | FuncOutputs[0];
   let pagesErrorOutput: undefined | FuncOutputs[0];
@@ -533,13 +532,12 @@ export async function handleNodeOutputs(
         filesHashes[routesManifestRelativePath] = routesManifestHash;
       }
 
-      const handlerFilePath = path.join(
-        functionDir,
-        handlerRelativeDir,
+      const handlerRelativePath = path.posix.join(
+        path.posix.relative(repoRoot, projectDir),
         '___next_launcher.cjs'
       );
-
-      await fs.mkdir(path.dirname(handlerFilePath), { recursive: true });
+      const handlerAbsolutePath = path.join(functionDir, handlerRelativePath);
+      await fs.mkdir(path.dirname(handlerAbsolutePath), { recursive: true });
       const handlerSource = getHandlerSource({
         projectRelativeDistDir: path.posix.relative(projectDir, distDir),
         prerenderFallbackFalseMap,
@@ -547,9 +545,9 @@ export async function handleNodeOutputs(
         nextConfig: config,
         nextEnvLoaderPathRelativeToProjectDir,
       });
-      await writeIfNotExists(handlerFilePath, handlerSource);
+      await writeIfNotExists(handlerAbsolutePath, handlerSource);
       if (filesHashes) {
-        filesHashes['___next_launcher.cjs'] = sha256(handlerSource);
+        filesHashes[handlerRelativePath] = sha256(handlerSource);
       }
 
       const operationType =
@@ -590,10 +588,7 @@ export async function handleNodeOutputs(
           slug: 'nextjs',
           version: nextVersion,
         },
-        handler: path.posix.join(
-          path.posix.relative(repoRoot, projectDir),
-          '___next_launcher.cjs'
-        ),
+        handler: handlerRelativePath,
         runtime: nodeVersion.runtime,
         maxDuration,
         supportsMultiPayloads: true,


### PR DESCRIPTION
```js
filesHashes['___next_launcher.cjs'] = hash
```
was wrong.

In a monorepo, this should be
```js
filesHashes['apps/foo/___next_launcher.cjs'] = hash
```

Just use the `.vc-config.json#handler` path for the hashes key as well. That is what we want here