### PR TITLE
Reproduce encoded pathname route misses

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "rm -rf dist; tsc --noEmit && node --experimental-transform-types build.mts",
-    "test": "vitest"
+    "test": "pnpm build && node --test test/*.test.js"
   },
   "devDependencies": {
     "@types/bytes": "3.1.1",

--- a/packages/adapter/test/node-handler.test.js
+++ b/packages/adapter/test/node-handler.test.js
@@ -1,0 +1,106 @@
+const assert = require('node:assert/strict');
+const { mkdtemp, mkdir, rm, writeFile } = require('node:fs/promises');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { afterEach, test } = require('node:test');
+const { getHandlerSource } = require('../dist/node-handler');
+
+const tempDirs = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((tempDir) => rm(tempDir, { recursive: true }))
+  );
+});
+
+async function writeModule(filePath, source) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, source);
+}
+
+async function createFixture() {
+  const fixtureDir = await mkdtemp(
+    path.join(tmpdir(), 'adapter-node-handler-')
+  );
+  tempDirs.push(fixtureDir);
+
+  await writeModule(
+    path.join(fixtureDir, 'node_modules/next/setup-node-env.js'),
+    ''
+  );
+  await writeModule(
+    path.join(fixtureDir, '.next/server/app/api/health/route.js'),
+    `
+      module.exports.handler = async (_req, res) => {
+        res.statusCode = 200;
+        res.end('health');
+      };
+    `
+  );
+  await writeFile(
+    path.join(fixtureDir, '.next/routes-manifest.json'),
+    JSON.stringify({
+      dynamicRoutes: [],
+      staticRoutes: [
+        {
+          page: '/api/health',
+          regex: '^/api/health$',
+          namedRegex: '^/api/health$',
+        },
+      ],
+    })
+  );
+  await writeFile(
+    path.join(fixtureDir, '.next/app-path-routes-manifest.json'),
+    JSON.stringify({
+      '/api/health/route': '/api/health',
+    })
+  );
+
+  const launcherPath = path.join(fixtureDir, '___next_launcher.cjs');
+  await writeFile(
+    launcherPath,
+    getHandlerSource({
+      projectRelativeDistDir: '.next',
+      prerenderFallbackFalseMap: {},
+    })
+  );
+
+  const originalCwd = process.cwd();
+  const handler = require(launcherPath);
+  process.chdir(originalCwd);
+
+  return handler;
+}
+
+async function invoke(handler, pathname, method = 'GET') {
+  const req = {
+    headers: {
+      host: 'localhost',
+      'x-matched-path': pathname,
+    },
+    method,
+    url: pathname,
+  };
+  let body = '';
+  const res = {
+    statusCode: 200,
+    end(chunk) {
+      body += chunk?.toString() || '';
+    },
+  };
+
+  await handler(req, res, {});
+
+  return { status: res.statusCode, body };
+}
+
+test('returns 404 when an encoded pathname misses the bundled route', async () => {
+  const handler = await createFixture();
+
+  assert.deepEqual(await invoke(handler, '/api/health'), {
+    status: 200,
+    body: 'health',
+  });
+  assert.equal((await invoke(handler, '/api/%68ealth', 'POST')).status, 404);
+});


### PR DESCRIPTION
### Why?

Vercel's filesystem routing can select the canonical `/api/health` function for an encoded request such as `POST /api/%68ealth`. The generated adapter handler then matches the raw `x-matched-path` value against the Next.js route manifests.

When that raw pathname does not match, the current fallback treats it as a Pages Router module path and attempts to load `.next/server/pages/api/%68ealth.js`. That throws `MODULE_NOT_FOUND`, producing a 500 instead of the expected 404. A focused regression test makes this failure reproducible before changing the routing contract.

### How?

Generate the real node launcher against fixture manifests containing only the App Router route `/api/health`. The test verifies that the canonical request reaches that route, then expects the encoded POST request to return 404.

Replace the stale Vitest command with Node's built-in test runner so the reproduction has no additional test dependency. Running `pnpm --filter @next-community/adapter-vercel test` intentionally fails on current `main` because the encoded request attempts to require `.next/server/pages/api/%68ealth.js`.

This draft changes only the test harness and reproduction. It does not change production routing behavior.
