### PR TITLE
Fix cache-control header for non-HTML sec-fetch-dest 404 route

### DIFF
--- a/packages/adapter/src/routing.ts
+++ b/packages/adapter/src/routing.ts
@@ -398,6 +398,11 @@ export function buildNonHtmlSecFetchDestNotFoundRoute(
     status: 404,
     headers: {
       'content-type': 'text/plain; charset=utf-8',
+      // The dest is a static asset, which would otherwise get a public,
+      // cacheable Cache-Control header. Override it to match the header
+      // Next.js itself sets for this response (see router-server.ts).
+      'cache-control':
+        'private, no-cache, no-store, max-age=0, must-revalidate',
     },
   };
 }


### PR DESCRIPTION
The dest is a static asset (/_next/static/not-found.txt), which gets
a default public, cacheable Cache-Control header from the CDN unless
overridden. This diverged from the Cache-Control Next.js itself sets
for the equivalent response when the app is invoked directly.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>