### PR TITLE
Fix missing cache-control override on the /_next/static/ plain text 404 route

### DIFF
--- a/packages/adapter/src/constants.ts
+++ b/packages/adapter/src/constants.ts
@@ -7,3 +7,13 @@ export const EDGE_FUNCTION_SIZE_LIMIT = 1024 * 1024;
 export { prettyBytes } from './pretty-bytes';
 
 export const INTERNAL_PAGES = ['_app', '_error', '_document'];
+
+// Headers for the plain text 404 served from `_next/static/not-found.txt`.
+// The dest is a static asset, which would otherwise get a public, cacheable
+// Cache-Control header from the CDN. Override it to match the header
+// Next.js itself sets for this response (see router-server.ts in
+// vercel/next.js).
+export const NOT_FOUND_TXT_HEADERS = {
+  'content-type': 'text/plain; charset=utf-8',
+  'cache-control': 'private, no-cache, no-store, max-age=0, must-revalidate',
+};

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { Route, RouteWithSrc } from '@vercel/routing-utils';
 import type { NextAdapter } from 'next';
 import { PHASE_PRODUCTION_BUILD } from 'next/constants';
+import { NOT_FOUND_TXT_HEADERS } from './constants';
 import {
   type FuncOutputs,
   handleEdgeOutputs,
@@ -731,9 +732,7 @@ const myAdapter: NextAdapter = {
           config.basePath,
           '_next/static/not-found.txt'
         ),
-        headers: {
-          'content-type': 'text/plain; charset=utf-8',
-        },
+        headers: NOT_FOUND_TXT_HEADERS,
       },
 
       // if i18n is enabled attempt removing locale prefix to check public files


### PR DESCRIPTION
This route shortcuts unmatched /_next/static/ requests at the CDN to a
static file (_next/static/not-found.txt), which otherwise gets a public,
cacheable Cache-Control header by default. That diverges from the
Cache-Control Next.js itself sets for the equivalent response when the
app is invoked directly. Extract the correct headers into a shared
constant so future call sites (e.g. sec-fetch-dest based 404s) stay
consistent.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>