### PR TITLE
Infer NEXT_DEPLOYMENT_ID for Skew Protection when platform doesn't inject it automatically

### DIFF
--- a/.changeset/config-skew-services.md
+++ b/.changeset/config-skew-services.md
@@ -2,4 +2,4 @@
 "@next-community/adapter-vercel": patch
 ---
 
-Assign `deploymentId` from `VERCEL_DEPLOYMENT_ID` in `modifyConfig` when Skew Protection is enabled and the platform did not inject `NEXT_DEPLOYMENT_ID` (e.g. services deployments).
+Assign `deploymentId` from `VERCEL_DEPLOYMENT_ID` in `modifyConfig` and to `process.env.NEXT_DEPLOYMENT_ID` when Skew Protection is enabled and the platform did not inject `NEXT_DEPLOYMENT_ID` (e.g. services deployments).

--- a/.changeset/config-skew-services.md
+++ b/.changeset/config-skew-services.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Assign `deploymentId` from `VERCEL_DEPLOYMENT_ID` in `modifyConfig` when Skew Protection is enabled and the platform did not inject `NEXT_DEPLOYMENT_ID` (e.g. services deployments).

--- a/.changeset/tidy-skew-services.md
+++ b/.changeset/tidy-skew-services.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Default `NEXT_DEPLOYMENT_ID` from `VERCEL_DEPLOYMENT_ID` in the Node.js handler when Skew Protection is enabled and the platform did not inject the variable (e.g. services deployments).

--- a/.changeset/tidy-skew-services.md
+++ b/.changeset/tidy-skew-services.md
@@ -1,5 +1,0 @@
----
-"@next-community/adapter-vercel": patch
----
-
-Default `NEXT_DEPLOYMENT_ID` from `VERCEL_DEPLOYMENT_ID` in the Node.js handler when Skew Protection is enabled and the platform did not inject the variable (e.g. services deployments).

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -44,6 +44,19 @@ const myAdapter: NextAdapter = {
         process.env.VERCEL_HASH_SALT;
     }
 
+    // This fallback covers builds where the `NEXT_DEPLOYMENT_ID` variable is missing,
+    // e.g. services deployments, where the framework is resolved per-service
+    // at the build time.
+    if (
+      ctx.phase === PHASE_PRODUCTION_BUILD &&
+      process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1' &&
+      process.env.VERCEL_DEPLOYMENT_ID &&
+      !process.env.NEXT_DEPLOYMENT_ID &&
+      config.deploymentId == null
+    ) {
+      config.deploymentId = process.env.VERCEL_DEPLOYMENT_ID;
+    }
+
     if (
       ctx.phase === PHASE_PRODUCTION_BUILD &&
       process.env.VERCEL_PREVIEW_COMMENTS_ENABLED === '1' &&

--- a/packages/adapter/src/node-handler.ts
+++ b/packages/adapter/src/node-handler.ts
@@ -27,17 +27,6 @@ export const getHandlerSource = (ctx: {
     loadEnvConfig('.', process.env.NODE_ENV === 'development');
   }
 
-  // Default NEXT_DEPLOYMENT_ID for Skew Protection when the platform did not
-  // inject it (e.g. services deployments, where the framework is resolved
-  // per-service).
-  if (
-    process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1' &&
-    process.env.VERCEL_DEPLOYMENT_ID &&
-    !process.env.NEXT_DEPLOYMENT_ID
-  ) {
-    process.env.NEXT_DEPLOYMENT_ID = process.env.VERCEL_DEPLOYMENT_ID;
-  }
-
   const _n_handler = (${
     ctx.isMiddleware
       ? () => {

--- a/packages/adapter/src/node-handler.ts
+++ b/packages/adapter/src/node-handler.ts
@@ -26,7 +26,18 @@ export const getHandlerSource = (ctx: {
     );
     loadEnvConfig('.', process.env.NODE_ENV === 'development');
   }
-  
+
+  // Default NEXT_DEPLOYMENT_ID for Skew Protection when the platform did not
+  // inject it (e.g. services deployments, where the framework is resolved
+  // per-service).
+  if (
+    process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1' &&
+    process.env.VERCEL_DEPLOYMENT_ID &&
+    !process.env.NEXT_DEPLOYMENT_ID
+  ) {
+    process.env.NEXT_DEPLOYMENT_ID = process.env.VERCEL_DEPLOYMENT_ID;
+  }
+
   const _n_handler = (${
     ctx.isMiddleware
       ? () => {
@@ -446,9 +457,9 @@ export const getHandlerSource = (ctx: {
           };
         }).toString()
   })()
-  
+
   module.exports = _n_handler
-  
+
   ${
     ctx.isMiddleware
       ? ''
@@ -458,7 +469,7 @@ export const getHandlerSource = (ctx: {
     }
   `
   }
-  
+
   `
     .replaceAll(
       'process.env.__PRIVATE_RELATIVE_DIST_DIR',

--- a/packages/adapter/src/node-handler.ts
+++ b/packages/adapter/src/node-handler.ts
@@ -27,6 +27,16 @@ export const getHandlerSource = (ctx: {
     loadEnvConfig('.', process.env.NODE_ENV === 'development');
   }
 
+  // Default NEXT_DEPLOYMENT_ID for Skew Protection when the platform did not
+  // inject it (e.g. services deployments).
+  if (
+    process.env.VERCEL_SKEW_PROTECTION_ENABLED === '1' &&
+    process.env.VERCEL_DEPLOYMENT_ID &&
+    !process.env.NEXT_DEPLOYMENT_ID
+  ) {
+    process.env.NEXT_DEPLOYMENT_ID = process.env.VERCEL_DEPLOYMENT_ID;
+  }
+
   const _n_handler = (${
     ctx.isMiddleware
       ? () => {


### PR DESCRIPTION
Vercel automatically injects `NEXT_DEPLOYMENT_ID` only when project's framework is set to `nextjs`, so if it's a `services` project or `fastapi` one that decided to switch to use `services`, then the env var won't be injected meaning such deployments won't use Skew Protection

This PR would allow to convert `VERCEL_DEPLOYMENT_ID` into `NEXT_DEPLOYMENT_ID` if Skew Protection is enabled, so it could be used with services deployments