### PR TITLE
Trace route entrypoint loading

### DIFF
--- a/.changeset/tidy-routes-trace.md
+++ b/.changeset/tidy-routes-trace.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Trace cold route entrypoint loading in generated Node launchers.

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -11,9 +11,10 @@
   },
   "scripts": {
     "build": "rm -rf dist; tsc --noEmit && node --experimental-transform-types build.mts",
-    "test": "vitest"
+    "test": "pnpm build && node --test test/*.test.cjs"
   },
   "devDependencies": {
+    "@opentelemetry/api": "1.9.0",
     "@types/bytes": "3.1.1",
     "@types/convert-source-map": "1.5.2",
     "@types/fs-extra": "8.0.0",

--- a/packages/adapter/src/node-handler.ts
+++ b/packages/adapter/src/node-handler.ts
@@ -384,6 +384,58 @@ export const getHandlerSource = (ctx: {
             return decoder.decode(bytes);
           }
 
+          const { SpanStatusCode, trace } =
+            require('next/dist/compiled/@opentelemetry/api') as typeof import('@opentelemetry/api');
+          const tracer = trace.getTracer('next.js', '0.0.1');
+          const routeEntrypoints = new Map<
+            string,
+            { handler: (...args: unknown[]) => unknown }
+          >();
+
+          function loadRouteEntrypoint(page: string, isAppDir: boolean) {
+            const key = `${isAppDir ? 'app' : 'pages'}:${page}`;
+            const cached = routeEntrypoints.get(key);
+            if (cached) return cached;
+
+            const route = page.replace(/\/(page|route)$/, '') || '/';
+            return tracer.startActiveSpan(
+              'load route entrypoint',
+              {
+                attributes: {
+                  'next.route': route,
+                  'next.router': isAppDir ? 'app' : 'pages',
+                  'next.span_category': 'nextjs',
+                  'next.span_name': 'load route entrypoint',
+                  'next.span_type': 'NextLauncher.loadRouteEntrypoint',
+                },
+              },
+              (span) => {
+                try {
+                  const mod = require(
+                    './' +
+                      path.posix.join(
+                        relativeDistDir,
+                        'server',
+                        isAppDir ? 'app' : 'pages',
+                        `${page === '/' ? 'index' : page}.js`
+                      )
+                  );
+                  routeEntrypoints.set(key, mod);
+                  return mod;
+                } catch (error) {
+                  span.recordException(error as Error);
+                  span.setStatus({
+                    code: SpanStatusCode.ERROR,
+                    message: error instanceof Error ? error.message : undefined,
+                  });
+                  throw error;
+                } finally {
+                  span.end();
+                }
+              }
+            );
+          }
+
           return async function handler(
             req: import('http').IncomingMessage,
             res: import('http').ServerResponse,
@@ -423,15 +475,7 @@ export const getHandlerSource = (ctx: {
                 req.url = `${parsedUrl.pathname}${parsedUrl.searchParams.size > 0 ? '?' : ''}${parsedUrl.searchParams.toString()}`;
               }
 
-              const mod = await require(
-                './' +
-                  path.posix.join(
-                    relativeDistDir,
-                    'server',
-                    isAppDir ? 'app' : 'pages',
-                    `${page === '/' ? 'index' : page}.js`
-                  )
-              );
+              const mod = await loadRouteEntrypoint(page, Boolean(isAppDir));
 
               await mod.handler(req, res, {
                 waitUntil: getRequestContext().waitUntil,

--- a/packages/adapter/test/node-handler.test.cjs
+++ b/packages/adapter/test/node-handler.test.cjs
@@ -1,0 +1,170 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { getHandlerSource } = require('../dist/node-handler.js');
+
+function createLauncher({ page, requestPath, routeModule, routeError }) {
+  const spans = [];
+  let routeRequires = 0;
+  let handlerFinished = false;
+
+  const span = {
+    end() {
+      spans[0].endedBeforeHandler = !handlerFinished;
+    },
+    recordException(error) {
+      spans[0].exception = error;
+    },
+    setStatus(status) {
+      spans[0].status = status;
+    },
+  };
+  const otel = {
+    SpanStatusCode: { ERROR: 2 },
+    trace: {
+      getTracer() {
+        return {
+          startActiveSpan(name, options, callback) {
+            spans.push({ name, attributes: options.attributes });
+            return callback(span);
+          },
+        };
+      },
+    },
+  };
+  const module = { exports: {} };
+  const source = getHandlerSource({
+    projectRelativeDistDir: '.next',
+    prerenderFallbackFalseMap: {},
+  });
+  requestPath = requestPath ?? (page.replace(/\/(page|route)$/, '') || '/');
+  const req = {
+    headers: { host: 'example.test', 'x-matched-path': requestPath },
+    url: requestPath,
+  };
+
+  function localRequire(id) {
+    if (id === 'path') return require('node:path');
+    if (id === 'next/setup-node-env') return {};
+    if (id === 'next/dist/compiled/@opentelemetry/api') return otel;
+    if (id.endsWith('.next/routes-manifest.json')) {
+      return {
+        dynamicRoutes: [],
+        staticRoutes: [{ page: requestPath, regex: `^${requestPath}$` }],
+      };
+    }
+    if (id.endsWith('.next/app-path-routes-manifest.json')) {
+      return page === requestPath ? {} : { [page]: requestPath };
+    }
+    if (id.includes('/server/app/') || id.includes('/server/pages/')) {
+      routeRequires += 1;
+      if (routeError) throw routeError;
+      return routeModule;
+    }
+    return {};
+  }
+
+  Function(
+    'require',
+    'module',
+    '__dirname',
+    'process',
+    source
+  )(localRequire, module, process.cwd(), { ...process, chdir() {} });
+
+  return {
+    async invoke() {
+      await module.exports(req, {}, {});
+      handlerFinished = true;
+    },
+    get routeRequires() {
+      return routeRequires;
+    },
+    spans,
+  };
+}
+
+test('traces a cold App Route entrypoint separately from its handler', async () => {
+  let handlerCalls = 0;
+  let resolveHandler;
+  let markHandlerStarted;
+  const handlerStarted = new Promise((resolve) => {
+    markHandlerStarted = resolve;
+  });
+  const launcher = createLauncher({
+    page: '/api/example/route',
+    routeModule: {
+      handler: () => {
+        handlerCalls += 1;
+        if (handlerCalls > 1) return;
+        markHandlerStarted();
+        return new Promise((resolve) => {
+          resolveHandler = resolve;
+        });
+      },
+    },
+  });
+
+  const invocation = launcher.invoke();
+  await handlerStarted;
+
+  assert.equal(launcher.routeRequires, 1);
+  assert.deepEqual(launcher.spans, [
+    {
+      name: 'load route entrypoint',
+      attributes: {
+        'next.route': '/api/example',
+        'next.router': 'app',
+        'next.span_category': 'nextjs',
+        'next.span_name': 'load route entrypoint',
+        'next.span_type': 'NextLauncher.loadRouteEntrypoint',
+      },
+      endedBeforeHandler: true,
+    },
+  ]);
+
+  resolveHandler();
+  await invocation;
+  await launcher.invoke();
+  assert.equal(launcher.routeRequires, 1);
+  assert.equal(launcher.spans.length, 1);
+});
+
+test('labels Pages Router entrypoints without filesystem attributes', async () => {
+  const launcher = createLauncher({
+    page: '/api/example',
+    routeModule: { handler() {} },
+  });
+
+  await launcher.invoke();
+
+  assert.deepEqual(launcher.spans, [
+    {
+      name: 'load route entrypoint',
+      attributes: {
+        'next.route': '/api/example',
+        'next.router': 'pages',
+        'next.span_category': 'nextjs',
+        'next.span_name': 'load route entrypoint',
+        'next.span_type': 'NextLauncher.loadRouteEntrypoint',
+      },
+      endedBeforeHandler: true,
+    },
+  ]);
+});
+
+test('records route entrypoint loading errors', async () => {
+  const error = new Error('failed to load route entrypoint');
+  const launcher = createLauncher({
+    page: '/api/example/route',
+    routeError: error,
+  });
+
+  await assert.rejects(launcher.invoke(), error);
+  assert.equal(launcher.spans[0].exception, error);
+  assert.deepEqual(launcher.spans[0].status, {
+    code: 2,
+    message: error.message,
+  });
+  assert.equal(launcher.spans[0].endedBeforeHandler, true);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   packages/adapter:
     devDependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.0
+        version: 1.9.0
       '@types/bytes':
         specifier: 3.1.1
         version: 3.1.1
@@ -73,7 +76,7 @@ importers:
         version: 11.2.0
       next:
         specifier: 16.3.0-canary.24
-        version: 16.3.0-canary.24(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.3.0-canary.24(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       picomatch:
         specifier: 4.0.1
         version: 4.0.1
@@ -588,6 +591,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@renovatebot/pep440@4.2.1':
     resolution: {integrity: sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==}
@@ -1734,6 +1741,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@renovatebot/pep440@4.2.1': {}
 
   '@swc/helpers@0.5.15':
@@ -2103,7 +2112,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@16.3.0-canary.24(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@16.3.0-canary.24(@opentelemetry/api@1.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 16.3.0-canary.24
       '@swc/helpers': 0.5.15
@@ -2122,6 +2131,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.3.0-canary.24
       '@next/swc-win32-arm64-msvc': 16.3.0-canary.24
       '@next/swc-win32-x64-msvc': 16.3.0-canary.24
+      '@opentelemetry/api': 1.9.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
## Summary

- add a `NextLauncher.loadRouteEntrypoint` span named `load route entrypoint` around the generated Node launcher's dynamic route-entrypoint import
- record stable route, router, span-name, span-type, and framework-category attributes for App Router and Pages Router entrypoints without exposing filesystem paths
- cache successfully loaded entrypoints so only the cold module load is traced, while keeping route handler execution outside the span
- record loading failures as OpenTelemetry exceptions and error status while preserving the original thrown error

This is an OpenTelemetry-only launcher span. The launcher loads the entrypoint before Next.js owns the request lifecycle, so Request Insights cannot attach it to a request without inventing parentage.

## Verification

- `pnpm format`
- `pnpm --filter @next-community/adapter-vercel test`
- `pnpm exec changeset status --since=origin/main`
