### PR TITLE
Revert "Fix i18n routing for API paths"

### DIFF
--- a/.changeset/fix-i18n-api-routes.md
+++ b/.changeset/fix-i18n-api-routes.md
@@ -1,5 +1,0 @@
----
-"@next-community/adapter-vercel": patch
----
-
-Prevent i18n routing from adding or removing locale prefixes for API routes.

--- a/.changeset/puny-candles-bet.md
+++ b/.changeset/puny-candles-bet.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Revert "Fix i18n routing for API paths"- #101

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -13,12 +13,10 @@ import {
   handleStaticOutputs,
 } from './outputs';
 import {
-  API_PATH_PREFIX_PATTERN,
   denormalizeNextDataRoutes,
   extractHeaders,
   extractOnMatchRoutes,
   extractRedirects,
-  getI18nPathPrefixExclusion,
   modifyWithRewriteHeaders,
   normalizeNextDataRoutes,
   normalizeRewrites,
@@ -110,9 +108,6 @@ const myAdapter: NextAdapter = {
     const shouldHandleMiddlewareDataResolving = routing.shouldNormalizeNextData;
 
     const i18nConfig = config.i18n;
-    const i18nPathPrefixExclusion = i18nConfig
-      ? getI18nPathPrefixExclusion(i18nConfig.locales)
-      : '';
     const vercelConfig: VercelConfig = {
       version: 3,
       overrides: {},
@@ -370,7 +365,9 @@ const myAdapter: NextAdapter = {
                 '/',
                 config.basePath,
                 '/'
-              )}${i18nPathPrefixExclusion}(.*)$`,
+              )}(?!(?:_next/.*|${config.i18n.locales
+                .map((locale) => escapeStringRegexp(locale))
+                .join('|')})(?:/.*|$))(.*)$`,
               // we aren't able to ensure trailing slash mode here
               // so ensure this comes after the trailing slash redirect
               dest: `${
@@ -468,7 +465,9 @@ const myAdapter: NextAdapter = {
                 '/',
                 config.basePath,
                 '/'
-              )}${i18nPathPrefixExclusion}(.*)$`,
+              )}(?!(?:_next/.*|${config.i18n.locales
+                .map((locale) => escapeStringRegexp(locale))
+                .join('|')})(?:/.*|$))(.*)$`,
               dest: `${path.posix.join(
                 '/',
                 config.basePath,
@@ -777,7 +776,9 @@ const myAdapter: NextAdapter = {
                       '/',
                       config.basePath,
                       '/'
-                    )}${i18nPathPrefixExclusion}(.*)$`,
+                    )}(?!(?:_next/.*|${config.i18n.locales
+                      .map((locale) => escapeStringRegexp(locale))
+                      .join('|')})(?:/.*|$))(.*)$`,
                     dest: `${path.posix.join(
                       '/',
                       config.basePath,
@@ -802,7 +803,7 @@ const myAdapter: NextAdapter = {
                 config.basePath
               )}/?(?:${config.i18n.locales
                 .map((locale) => escapeStringRegexp(locale))
-                .join('|')})/(?!${API_PATH_PREFIX_PATTERN})(.*)`,
+                .join('|')})/(.*)`,
               dest: `${path.posix.join('/', config.basePath, '/')}$1`,
               check: true,
             },

--- a/packages/adapter/src/routing.ts
+++ b/packages/adapter/src/routing.ts
@@ -1,24 +1,11 @@
 import type { RouteWithSrc } from '@vercel/routing-utils';
 import type { NextAdapter, NextConfig } from 'next';
-import { escapeStringRegexp } from './utils';
 
 type AdapterRouting = Parameters<
   NonNullable<NextAdapter['onBuildComplete']>
 >[0]['routing'];
 
 type AdapterRoute = AdapterRouting['beforeFiles'][0];
-
-export const API_PATH_PREFIX_PATTERN = 'api(?:/.*|$)';
-
-/**
- * Prevent Vercel's internal i18n routing from adding a locale prefix to
- * framework-internal assets, Pages API routes, and already-localized paths.
- */
-export function getI18nPathPrefixExclusion(locales: readonly string[]): string {
-  return `(?!(?:_next/.*|api|${locales
-    .map((locale) => escapeStringRegexp(locale))
-    .join('|')})(?:/.*|$))`;
-}
 
 export function modifyWithRewriteHeaders(
   rewrites: RouteWithSrc[],


### PR DESCRIPTION
Reverts nextjs/adapter-vercel#81

We believe this is causing routing issues for pages router apps that have i18n enabled. 