### PR TITLE
Fix manifest unmatched case to render404

### DIFF
--- a/.changeset/calm-routes-render.md
+++ b/.changeset/calm-routes-render.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Render the framework not-found response when a request does not match a bundled route.

--- a/packages/adapter/src/node-handler.ts
+++ b/packages/adapter/src/node-handler.ts
@@ -406,8 +406,9 @@ export const getHandlerSource = (ctx: {
                 matches,
               } = matchUrlToPage(urlPathname);
               if (page === null) {
-                res.statusCode = 404;
-                res.end('This page could not be found');
+                await routerServerGlobal[RouterServerContextSymbol]?.[
+                  '.'
+                ].render404?.(req, res);
                 return;
               }
               const isAppDir = page.match(/\/(page|route)$/);


### PR DESCRIPTION
Follow up of https://github.com/nextjs/adapter-vercel/pull/88

At https://github.com/nextjs/adapter-vercel/pull/88, the change was to return 404 text response when manifest did not match, but this affected basic `/non-existent` routes to return text response instead of HTML. Therefore this PR modifies to render the given not-found/404 page.

Confirmed all e2e deploy tests passes BUT the encoded URL case:

https://github.com/vercel/next.js/actions/runs/32365548594/job/96414392365#step:35:459