### PR TITLE
Revert "Do not fall back to URL when manifest unmatched (#88)"

### DIFF
--- a/.changeset/light-stamps-shake.md
+++ b/.changeset/light-stamps-shake.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Revert "Do not fall back to URL when manifest unmatched (#88)"

--- a/.changeset/tidy-pumas-route.md
+++ b/.changeset/tidy-pumas-route.md
@@ -1,5 +1,0 @@
----
-"@next-community/adapter-vercel": patch
----
-
-Return 404 before loading a request path that does not match a bundled route.

--- a/packages/adapter/src/node-handler.ts
+++ b/packages/adapter/src/node-handler.ts
@@ -198,7 +198,7 @@ export const getHandlerSource = (ctx: {
           }
 
           function matchUrlToPage(urlPathname: string): {
-            matchedPathname: string | null;
+            matchedPathname: string;
             locale?: string;
             matches?: RegExpMatchArray | null;
           } {
@@ -265,7 +265,8 @@ export const getHandlerSource = (ctx: {
 
             // we should have matched above but if not return back
             return {
-              matchedPathname: inversedAppRoutesManifest[urlPathname] ?? null,
+              matchedPathname:
+                inversedAppRoutesManifest[urlPathname] || urlPathname,
               locale: normalizeResult.locale,
             };
           }
@@ -405,11 +406,6 @@ export const getHandlerSource = (ctx: {
                 locale,
                 matches,
               } = matchUrlToPage(urlPathname);
-              if (page === null) {
-                res.statusCode = 404;
-                res.end('This page could not be found');
-                return;
-              }
               const isAppDir = page.match(/\/(page|route)$/);
               let addedMatchesToUrl = false;
 


### PR DESCRIPTION
This reverts commit 7785ac3b8bc78aab91a3b52c054f29eba0ff7362.

The change was breaking Next.js `test/e2e/no-page-props/no-page-props.test.ts Error no pageProps › should load 404 page correctly` test which expected 404 HTML but received 404 text:

https://github.com/vercel/next.js/actions/runs/32186133832/job/95870319775#step:32:1155