### PR TITLE
Exempt pre-release Version Packages PRs from the changeset check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,9 @@ jobs:
   enforce-changeset:
     name: Enforce Changeset
     runs-on: ubuntu-latest
-    if: "${{ github.event.pull_request.title != 'chore: version packages' }}"
+    # The changesets bot suffixes the title in pre-release mode ("chore: version
+    # packages (beta)"), so match on the prefix rather than the exact title.
+    if: "${{ !startsWith(github.event.pull_request.title, 'chore: version packages') }}"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

The `Enforce Changeset` exemption matches the exact title `chore: version packages`, but this repo runs changesets in pre-release mode, where the bot titles its release PR `chore: version packages (beta)`. The exemption misses, so the check runs against the one PR that legitimately consumes every changeset — and fails, currently blocking #110 (the release that publishes the `initialMetadata` adapter change from #107).

## What

Match on the title prefix (`startsWith`) instead of exact equality. No changeset: workflow-only change (and the enforcement script itself is what's being fixed).

After this merges, re-running the failed check on #110 picks up the fixed condition via the merge ref and the job skips as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)