### PR TITLE
Emit `onMiss` on prerender configs

### DIFF
--- a/.changeset/prerender-on-miss.md
+++ b/.changeset/prerender-on-miss.md
@@ -1,0 +1,20 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Emit `onMiss` on prerender configs, derived per prerender group from the
+Next.js response classification: `sync` when the canonical response is
+`complete`, `dynamic` when it is `initial` or `empty`, omitted when the group
+is unclassified (older Next.js, `fallback: false` templates) or a Route
+Handler.
+
+**Behavior change once the platform proxy flag is enabled:** upgrading the
+adapter changes cache-miss behavior for every PPR route with dynamic holes.
+Misses on those routes are served dynamically per request while a single
+coalesced async revalidation backfills the shell, instead of blocking on a
+synchronous revalidation. This is intended and cost-neutral — a blocking miss
+on a dynamic-hole route already costs two invocations — but the change in
+serving behavior is visible. Routes whose stored shell is a complete response
+emit `onMiss: "sync"` and keep today's collapsed single-invocation miss
+handling. The field is inert until the platform proxy flag is enabled;
+until then all routes keep the current blocking-miss behavior.

--- a/packages/adapter/src/outputs.test.ts
+++ b/packages/adapter/src/outputs.test.ts
@@ -217,4 +217,111 @@ describe('handlePrerenderOutputs', () => {
       expect(config).not.toHaveProperty('initialMetadata');
     });
   });
+
+  describe('onMiss', () => {
+    // Next.js classifies only a group's canonical UI output, while the
+    // platform reads each path's config independently, so the assertions run
+    // the canonical HTML output together with its unclassified RSC sibling
+    // and check both written configs.
+    function makeRscSibling(): AdapterOutput['PRERENDER'] {
+      return {
+        ...makePrerenderOutput(undefined),
+        id: 'prerender-2',
+        pathname: '/blog.rsc',
+      };
+    }
+
+    async function writtenConfigs(outputs: AdapterOutput['PRERENDER'][]) {
+      await handlePrerenderOutputs(outputs, {
+        config: {},
+        vercelOutputDir,
+        nodeOutputsParentMap,
+        rscContentType: RSC_CONTENT_TYPE,
+        varyHeader: 'rsc',
+      });
+
+      return Promise.all(
+        outputs.map(async (output) =>
+          JSON.parse(
+            await fs.readFile(
+              path.join(
+                vercelOutputDir,
+                'functions',
+                `${output.pathname.slice(1)}.prerender-config.json`
+              ),
+              'utf8'
+            )
+          )
+        )
+      );
+    }
+
+    it("emits 'sync' on the HTML and RSC configs of a complete group", async () => {
+      const [htmlConfig, rscConfig] = await writtenConfigs([
+        {
+          ...makePrerenderOutput(undefined),
+          routeType: 'page',
+          response: 'complete',
+          compute: 'static',
+        },
+        makeRscSibling(),
+      ]);
+
+      expect(htmlConfig.onMiss).toBe('sync');
+      expect(rscConfig.onMiss).toBe('sync');
+    });
+
+    it("emits 'dynamic' on the HTML and RSC configs of an initial group", async () => {
+      const [htmlConfig, rscConfig] = await writtenConfigs([
+        {
+          ...makePrerenderOutput(undefined),
+          routeType: 'page',
+          response: 'initial',
+          compute: 'resuming',
+        },
+        makeRscSibling(),
+      ]);
+
+      expect(htmlConfig.onMiss).toBe('dynamic');
+      expect(rscConfig.onMiss).toBe('dynamic');
+    });
+
+    it("emits 'dynamic' on the HTML and RSC configs of an empty group", async () => {
+      const [htmlConfig, rscConfig] = await writtenConfigs([
+        {
+          ...makePrerenderOutput(undefined),
+          routeType: 'page',
+          response: 'empty',
+          compute: 'blocking',
+        },
+        makeRscSibling(),
+      ]);
+
+      expect(htmlConfig.onMiss).toBe('dynamic');
+      expect(rscConfig.onMiss).toBe('dynamic');
+    });
+
+    it('omits onMiss when Next.js supplied no classification', async () => {
+      // Older Next.js versions and fallback: false templates carry no
+      // taxonomy; the key must be absent, not empty or undefined.
+      const [config] = await writtenConfigs([makePrerenderOutput(undefined)]);
+
+      expect(config).not.toHaveProperty('onMiss');
+    });
+
+    it('omits onMiss for Route-Handler-only groups', async () => {
+      // Route Handlers are classified but have no HTML shell to serve or
+      // backfill, so the heuristic does not apply to them.
+      const [config] = await writtenConfigs([
+        {
+          ...makePrerenderOutput(undefined),
+          routeType: 'route',
+          response: 'complete',
+          compute: 'static',
+        },
+      ]);
+
+      expect(config).not.toHaveProperty('onMiss');
+    });
+  });
 });

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -653,6 +653,29 @@ export async function handlePrerenderOutputs(
   const fsSema = new Sema(16, { capacity: prerenderOutputs.length });
   const functionsDir = path.join(vercelOutputDir, 'functions');
 
+  // How the platform should serve a cache miss, derived per prerender group
+  // from the canonical UI output's response classification. A `complete`
+  // response means the stored shell is the finished page, so a miss keeps the
+  // blocking revalidation whose request collapsing yields one invocation and
+  // one cache write (`sync`). An `initial` or `empty` response has dynamic
+  // holes, where a blocking miss already costs two invocations (shell +
+  // resume), so serving the miss dynamically while one coalesced async
+  // revalidation backfills the shell is cost-neutral and answers the request
+  // immediately (`dynamic`). Next.js classifies only a group's canonical UI
+  // output, and the platform reads each path's config independently, so the
+  // mode is captured per group here and applied to every sibling below.
+  // Route Handler groups and unclassified groups (older Next.js,
+  // `fallback: false` templates) get no entry and keep the legacy behavior.
+  const onMissModes = new Map<number, 'sync' | 'dynamic'>();
+  for (const output of prerenderOutputs) {
+    if (output.routeType !== 'route' && output.response !== undefined) {
+      onMissModes.set(
+        output.groupId,
+        output.response === 'complete' ? 'sync' : 'dynamic'
+      );
+    }
+  }
+
   await Promise.all(
     prerenderOutputs.map(async (output) => {
       await fsSema.acquire();
@@ -801,6 +824,10 @@ export async function handlePrerenderOutputs(
 
               bypassToken: output.config.bypassToken,
               experimentalBypassFor: output.config.bypassFor,
+
+              // undefined for groups without a classified UI output, which
+              // omits the key from the serialized config
+              onMiss: onMissModes.get(output.groupId),
 
               // Build-time serving metadata, carried verbatim from Next.js.
               // Next.js sets the taxonomy only on a prerender group's primary


### PR DESCRIPTION
> [!NOTE]
> **Draft as a merge-order guard, not review status.** This PR is ready for review now. It stays draft until the vercel/proxy dispatch PR and the vercel/api carriage PR merge and the proxy flag is enabled — merging the adapter side first would ship a field nothing consumes yet, and the changeset's behavior-change notice must land in the same release window as the platform actually honoring it.

## Why

- BOA prerender configs gain `onMiss: "sync" | "dynamic"`, controlling how the platform serves a prerender cache miss. Absence means the current behavior: block the request on a synchronous revalidation. `dynamic` means serve the miss dynamically per request while a single coalesced async revalidation backfills the shell. RFC (approved): https://app.notion.com/p/3c9e06b059c481e4b84ee7e2abc06488
- The adapter derives the mode per prerender group from Next.js's existing response classification (`routeType` / `response` / `compute`, emitted since `next@16.3.0-canary.96` — the pin main already carries from #107). This is a framework heuristic with no developer override.
- The mapping, and why:
  - `response: "complete"` → `onMiss: "sync"`, emitted explicitly: the stored shell is the finished response, so blocking miss revalidation with its request collapsing (one invocation, one cache write) stays the cheapest way to serve it. Emitting the value rather than relying on absence makes new-Next builds distinguishable from legacy configs that merely lack classification data.
  - `response: "initial" | "empty"` → `onMiss: "dynamic"`: routes with dynamic holes already cost two invocations on a sync miss (shell render + resume), so per-request dynamic serving plus one coalesced async shell backfill is cost-neutral — and the miss is answered immediately instead of blocking.
  - Unclassified groups (older Next.js, `fallback: false` templates) and Route-Handler-only groups (`routeType: "route"`) omit the key entirely — never an empty or undefined value — and keep the legacy blocking-miss behavior.
- Supersedes #98 (`staticHint`), which was the direct skeleton for this change: same group-level derivation point, but emitting the `onMiss` enum for classified groups instead of a boolean hint. `staticHint` is not emitted.

## What

- `handlePrerenderOutputs` builds a group-level map keyed by `groupId` from the group's canonical UI output (`routeType !== 'route' && response !== undefined`) before any outputs are processed, then applies it to every written prerender config in the group. Next.js classifies only the canonical output, but the platform reads each path's config independently, so the group's HTML and RSC configs must both carry the value.
- `initialMetadata` emission (#107) is untouched; this PR only adds the `onMiss` key.
- No Next.js pin bump: main already pins `16.3.0-canary.96`, the first canary with the classification fields.
- Patch changeset for the `chore: version packages (beta)` flow, written to be conspicuous: once the proxy flag is enabled, upgrading the adapter changes miss behavior for all PPR routes with dynamic holes — intended and cost-neutral, but visible.

## Validation

- Unit tests in `outputs.test.ts` using the existing `makePrerenderOutput` / written-config helpers: a complete group emits `onMiss: "sync"` on both its HTML and RSC configs; initial and empty groups emit `"dynamic"` on both; an unclassified output gains no `onMiss` property; a Route-Handler-only group (`routeType: "route"`) gains none.
- `biome check` on touched files, `vitest run` (10/10), and `tsc --noEmit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)