### PR TITLE
Limit Turbopack read concurrency to 4

### DIFF
--- a/.changeset/thick-ties-attend.md
+++ b/.changeset/thick-ties-attend.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Limit Turbopack read concurrency to 4

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -29,6 +29,12 @@ import { escapeStringRegexp, getImagesConfig } from './utils';
 const myAdapter: NextAdapter = {
   name: 'Vercel',
   async modifyConfig(config, ctx) {
+    if (ctx.phase === PHASE_PRODUCTION_BUILD && process.env.CI) {
+      // A workaround to speedup Turbopack builds (particularly warm builds). Vercel build cache
+      // reads currently slows down dramatically with too many concurrent reads, so we limit to 4.
+      process.env.TURBO_ENGINE_READ_CONCURRENCY = '4';
+    }
+
     if (ctx.phase === PHASE_PRODUCTION_BUILD) {
       config.experimental.supportsImmutableAssets =
         // Default to true, allow users to opt-out


### PR DESCRIPTION
context: https://vercel.slack.com/archives/C09R44U5HQW/p1787585395416629

```
      // A workaround to speedup Turbopack builds (particularly warm builds). Vercel build cache
      // reads currently slows down dramatically with too many concurrent reads, so we limit to 4.
```