### PR TITLE
Fix duplicate fetch spans in OpenTelemetry-instrumented apps

### DIFF
--- a/.changeset/0000-fix-duplicate-fetch-spans.md
+++ b/.changeset/0000-fix-duplicate-fetch-spans.md
@@ -1,0 +1,5 @@
+---
+"@next-community/adapter-vercel": patch
+---
+
+Prevent duplicate fetch spans by preserving the automatic fetch instrumentation opt-out when OpenTelemetry is detected during the build.

--- a/packages/adapter/src/outputs.test.ts
+++ b/packages/adapter/src/outputs.test.ts
@@ -3,8 +3,93 @@ import os from 'node:os';
 import path from 'node:path';
 import type { AdapterOutput } from 'next';
 import { AdapterOutputType } from 'next/dist/shared/lib/constants';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { type FuncOutputs, handlePrerenderOutputs } from './outputs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type FuncOutputs,
+  handleNodeOutputs,
+  handlePrerenderOutputs,
+} from './outputs';
+
+describe('handleNodeOutputs automatic fetch instrumentation', () => {
+  let projectDir: string;
+  let distDir: string;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adapter-node-'));
+    distDir = path.join(projectDir, '.next');
+    await fs.mkdir(distDir);
+    await fs.writeFile(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify({ engines: { node: '22.x' } })
+    );
+    await fs.writeFile(path.join(distDir, 'routes-manifest.json'), '{}');
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    AdapterOutputType.PAGES,
+    AdapterOutputType.APP_ROUTE,
+    AdapterOutputType.MIDDLEWARE,
+  ] as const)('serializes the current build flag for %s', async (type) => {
+    const isMiddleware = type === AdapterOutputType.MIDDLEWARE;
+    const output = {
+      id: 'node-output',
+      type,
+      pathname: '/example',
+      sourcePage: isMiddleware ? 'middleware' : '/example',
+      filePath: path.join(distDir, 'example.js'),
+      runtime: 'nodejs',
+      assets: {},
+      assetsHashes: {},
+      config: {},
+    } satisfies FuncOutputs[number];
+
+    for (const [value, expected] of [
+      ['1', true],
+      [undefined, false],
+      ['', false],
+      ['0', false],
+      ['true', false],
+      ['1', true],
+    ] as const) {
+      vi.stubEnv(
+        'VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION',
+        value
+      );
+      const vercelOutputDir = await fs.mkdtemp(
+        path.join(projectDir, 'output-')
+      );
+
+      await handleNodeOutputs([output], {
+        config: {},
+        distDir,
+        repoRoot: projectDir,
+        projectDir,
+        nextVersion: '16.3.0-canary.96',
+        isMiddleware,
+        prerenderFallbackFalseMap: {},
+        vercelOutputDir,
+      });
+
+      const config = JSON.parse(
+        await fs.readFile(
+          path.join(vercelOutputDir, 'functions/example.func/.vc-config.json'),
+          'utf8'
+        )
+      );
+      expect(
+        config.shouldDisableAutomaticFetchInstrumentation,
+        `flag: ${value}`
+      ).toBe(expected);
+      expect(config.launcherType).toBe('Nodejs');
+      expect(config.useWebApi).toBe(isMiddleware);
+    }
+  });
+});
 
 const RSC_CONTENT_TYPE = 'text/x-component';
 const HTML_CONTENT_TYPE = 'text/html; charset=utf-8';

--- a/packages/adapter/src/outputs.ts
+++ b/packages/adapter/src/outputs.ts
@@ -246,6 +246,7 @@ type NodeFunctionConfig = Pick<
   | 'supportsMultiPayloads'
   | 'supportsResponseStreaming'
   | 'experimentalAllowBundling'
+  | 'shouldDisableAutomaticFetchInstrumentation'
 > & {
   // these are build output API specific not on Lambda class
   filePathMap: Record<string, string>;
@@ -615,6 +616,9 @@ export async function handleNodeOutputs(
         supportsMultiPayloads: true,
         supportsResponseStreaming: true,
         experimentalAllowBundling: true,
+        shouldDisableAutomaticFetchInstrumentation:
+          process.env.VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION ===
+          '1',
         // middleware handler always expects Request/Response interface
         useWebApi: isMiddleware,
         launcherType: 'Nodejs',


### PR DESCRIPTION
## Problem

Vercel's runtime creates automatic fetch spans even when the application already instruments those requests. This adds a runtime span for the same network operation covered by custom instrumentation.

The CLI detects OpenTelemetry and sets `VERCEL_TRACING_DISABLE_AUTOMATIC_FETCH_INSTRUMENTATION=1` during the build. Legacy Next builders copy this into Lambda metadata. This adapter omits `shouldDisableAutomaticFetchInstrumentation` from `.vc-config.json`, so the deployed Lambda never receives the runtime opt-out.

## Solution

Copy the build signal into every Node.js function config, including Node middleware. Set the boolean to `true` only when the env value is exactly `'1'`.

Existing deployment handling maps that field back to the runtime env var. The runtime then skips automatic fetch spans while preserving the application's custom instrumentation. No dependency upgrade required.

Validation:

- Regression tests read emitted `.vc-config.json` for pages, route handlers, and middleware. Cover enabled, unset, empty, invalid, and changing values.
- All 13 tests pass. Package build, TypeScript checks, explicit test-file typecheck, and Biome pass.
- Local transport check confirms serialized `true` reaches runtime env `'1'`; `false` leaves it absent.

Preview Lambda and fresh trace verification remain pending.

## Related PR(s)

- https://github.com/vercel/vercel/pull/14345 added the equivalent propagation to legacy builders.
